### PR TITLE
Preserve reply draft when swipe-replying to another post

### DIFF
--- a/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
+++ b/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
@@ -3166,6 +3166,37 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     private func replyToPost(postNumber: String) {
         guard let threadNo = Int(threadNumber) else { return }
 
+        // If a compose view already exists (visible or minimized), append the
+        // quote to it so the user's in-progress content is preserved.
+        if let composeVC = activeComposeVC {
+            if let postNo = Int(postNumber) {
+                composeVC.insertQuote(postNo)
+            }
+
+            if isComposeMinimized {
+                isComposeMinimized = false
+
+                if composeVC.parent != nil {
+                    composeVC.willMove(toParent: nil)
+                    composeVC.view.removeFromSuperview()
+                    composeVC.removeFromParent()
+                }
+
+                let navController = UINavigationController(rootViewController: composeVC)
+                navController.modalPresentationStyle = .pageSheet
+                navController.isModalInPresentation = true
+                if let sheet = navController.sheetPresentationController {
+                    sheet.detents = [.medium(), .large()]
+                    sheet.prefersGrabberVisible = true
+                }
+                present(navController, animated: true)
+                updateFloatingReplyButton()
+            } else {
+                showToast(message: "Added >>\(postNumber) to reply")
+            }
+            return
+        }
+
         let quoteText = ">>\(postNumber)"
         let composeVC = ComposeViewController(board: boardAbv, threadNumber: threadNo, quoteText: quoteText)
         composeVC.delegate = self


### PR DESCRIPTION
## Summary
- Fix swipe-Reply flow in `threadRepliesTV` that erased in-progress reply content when a compose view was minimized.
- `replyToPost` now reuses the existing `activeComposeVC` via `insertQuote` instead of constructing a fresh `ComposeViewController` (which overwrote the typed text and previous quote in `viewDidLoad`).
- When the compose is minimized, the fix also restores it (same re-presentation pattern as `floatingReplyButtonTapped`) so the user can continue editing immediately.

## Repro
1. Swipe a reply → tap Reply (compose opens with `>>A` prefilled).
2. Type some content, minimize compose.
3. Swipe a different reply → tap Reply.
4. Before: compose re-opens with only `>>B` — prior text and `>>A` are gone.
5. After: compose re-opens with prior text preserved and `>>B` appended.

## Test plan
- [ ] Swipe Reply on post A, type content, minimize, swipe Reply on post B → content preserved, both `>>A` and `>>B` present.
- [ ] Swipe Reply with no existing compose → new compose opens with `>>A` (unchanged behavior).
- [ ] Tap a post number inline with active compose (existing `toggleQuote` path) still appends via `insertQuote`.
- [ ] Floating "Continue Reply" button still restores a minimized compose correctly.

https://claude.ai/code/session_01V7daz1YsMPkC11fR5tbJic