### PR TITLE
Avoid false "Loading Error" alerts on app resume

### DIFF
--- a/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
+++ b/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
@@ -1914,6 +1914,26 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     private func handleLoadError() {
         isLoading = false
 
+        // If we already have content loaded, keep showing it and silently recover.
+        // This avoids false "Loading Error" alerts when the app is backgrounded and resumed.
+        if !threadReplies.isEmpty {
+            tableView.refreshControl?.endRefreshing()
+            return
+        }
+
+        // Don't present alerts while the app is inactive/backgrounded.
+        // Retry once when we become active again.
+        if UIApplication.shared.applicationState != .active {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                guard let self = self else { return }
+                if UIApplication.shared.applicationState == .active && self.threadReplies.isEmpty {
+                    self.isLoading = true
+                    self.loadInitialData()
+                }
+            }
+            return
+        }
+
         let alert = UIAlertController(
             title: "Loading Error",
             message: "Failed to load thread data. Please try again.",


### PR DESCRIPTION
### Motivation
- Background/foreground transitions could trigger the `handleLoadError()` alert even when the thread was already loaded, creating a false error prompt and interrupting the user experience.

### Description
- Update `handleLoadError()` in `Channer/ViewControllers/Thread Replies/threadRepliesTV.swift` to silently return and end the refresh control when `threadReplies` is not empty.
- Add a guard to skip presenting the alert while `UIApplication.shared.applicationState` is not `.active` and schedule a short delayed retry that calls `loadInitialData()` once the app becomes active and `threadReplies` is still empty.
- Preserve the original alert flow when there is no existing content and the app is active.

### Testing
- Verified the change via `git diff` and file inspection (`nl`) to confirm the new logic was inserted in `handleLoadError()` and the surrounding context is unchanged.
- Successfully staged and committed the change with `git commit`, and command outputs indicated the file was updated without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a365a838832d9cd520bacb37b5b0)