### PR TITLE
Fix clipped search mode segmented control on iOS

### DIFF
--- a/Channer/ViewControllers/Home/SearchViewController.swift
+++ b/Channer/ViewControllers/Home/SearchViewController.swift
@@ -427,7 +427,7 @@ class SearchViewController: UIViewController {
     }
 
     private func configureTableHeader() {
-        let headerHeight: CGFloat = 44
+        let headerHeight: CGFloat = 52
         let headerView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: headerHeight))
         headerView.backgroundColor = ThemeManager.shared.backgroundColor
 
@@ -450,7 +450,7 @@ class SearchViewController: UIViewController {
                 trailing
             ])
         } else {
-            segmentedControl.frame = headerView.bounds.insetBy(dx: 16, dy: 6)
+            segmentedControl.frame = headerView.bounds.insetBy(dx: 16, dy: 10)
             segmentedControl.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             headerView.addSubview(segmentedControl)
         }
@@ -463,7 +463,7 @@ class SearchViewController: UIViewController {
         if headerView.frame.width != tableView.bounds.width {
             headerView.frame.size.width = tableView.bounds.width
             if !Self.isMacCatalyst {
-                segmentedControl.frame = headerView.bounds.insetBy(dx: 16, dy: 6)
+                segmentedControl.frame = headerView.bounds.insetBy(dx: 16, dy: 10)
             }
             tableView.tableHeaderView = headerView
         }


### PR DESCRIPTION
### Motivation
- The Search screen’s segmented control (`Results / History / Saved`) was rendering too close to the top and appeared visually clipped on iPhone, so the header needs slightly more vertical space and larger insets.

### Description
- Increased the table header height from `44` to `52` in `SearchViewController.swift` to give the segmented control more vertical room.
- Increased the iOS segmented control vertical inset from `dy: 6` to `dy: 10` and updated the `updateTableHeaderLayout` code to preserve the new inset when the header is relaid out.

### Testing
- No automated tests were run for this UI layout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a3f18674832dbfa8cb00b687dbcc)