### PR TITLE
Add XT-style unread tracking and thread read-state monitoring

### DIFF
--- a/Channer/Application/AppDelegate.swift
+++ b/Channer/Application/AppDelegate.swift
@@ -275,6 +275,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                             var replyPreview = ""
                             var latestReplyNo: String? = nil
                             if let posts = json["posts"].array, posts.count > 1 {
+                                let postNumbers = posts.map { $0["no"].stringValue }.filter { !$0.isEmpty }
+                                ThreadReadStateManager.shared.updateThread(
+                                    boardAbv: favorite.boardAbv,
+                                    threadNumber: favorite.number,
+                                    postNumbers: postNumbers,
+                                    boardPage: favorite.boardPage,
+                                    purgePosition: favorite.purgePosition,
+                                    replyCount: currentReplies,
+                                    imageCount: firstPost["images"].int
+                                )
+                                ThreadReadStateManager.shared.markUnread(
+                                    boardAbv: favorite.boardAbv,
+                                    threadNumber: favorite.number,
+                                    postNumbers: Array(postNumbers.suffix(newReplies))
+                                )
+
                                 // Get the last post (most recent reply)
                                 let latestPost = posts[posts.count - 1]
                                 let hasImage = latestPost["tim"].exists()
@@ -644,10 +660,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         // Use NotificationManager's unread count for badge
         let notificationBadgeCount = NotificationManager.shared.getUnreadCount()
+        let threadUnreadCount = ThreadReadStateManager.shared.totalUnreadCount()
 
         // Update the application badge
         DispatchQueue.main.async {
-            UIApplication.shared.applicationIconBadgeNumber = notificationBadgeCount
+            UIApplication.shared.applicationIconBadgeNumber = notificationBadgeCount + threadUnreadCount
         }
     }
     

--- a/Channer/Utilities/BackgroundTaskManager.swift
+++ b/Channer/Utilities/BackgroundTaskManager.swift
@@ -311,6 +311,24 @@ class BackgroundTaskManager {
                 var replyPreview = ""
                 var latestReplyNo: String? = nil
                 if let posts = json["posts"].array, posts.count > 1 {
+                    let postNumbers = posts.map { $0["no"].stringValue }.filter { !$0.isEmpty }
+                    await MainActor.run {
+                        ThreadReadStateManager.shared.updateThread(
+                            boardAbv: favorite.boardAbv,
+                            threadNumber: favorite.number,
+                            postNumbers: postNumbers,
+                            boardPage: favorite.boardPage,
+                            purgePosition: favorite.purgePosition,
+                            replyCount: currentReplies,
+                            imageCount: firstPost["images"].int
+                        )
+                        ThreadReadStateManager.shared.markUnread(
+                            boardAbv: favorite.boardAbv,
+                            threadNumber: favorite.number,
+                            postNumbers: Array(postNumbers.suffix(newReplies))
+                        )
+                    }
+
                     let latestPost = posts[posts.count - 1]
                     let hasImage = latestPost["tim"].exists()
 
@@ -720,7 +738,7 @@ class BackgroundTaskManager {
             return
         }
 
-        let badgeCount = NotificationManager.shared.getUnreadCount()
+        let badgeCount = NotificationManager.shared.getUnreadCount() + ThreadReadStateManager.shared.totalUnreadCount()
 
         DispatchQueue.main.async {
             UIApplication.shared.applicationIconBadgeNumber = badgeCount

--- a/Channer/ViewControllers/Board/boardTV.swift
+++ b/Channer/ViewControllers/Board/boardTV.swift
@@ -21,11 +21,13 @@ struct ThreadData: Codable {
     var categoryId: String? // Category ID for organizing favorites
     let lastReplyTime: Int? // Unix timestamp of last reply for sorting
     var bumpIndex: Int? // Original board bump order (position from top)
+    var boardPage: Int? // 4chan catalog page where the thread was last seen
+    var purgePosition: Int? // Approximate bump-order position, useful for purge risk
     var isDead: Bool = false // Flag to indicate thread no longer exists (404)
 
     // Custom coding keys to include all properties
     enum CodingKeys: String, CodingKey {
-        case number, stats, title, comment, imageUrl, boardAbv, replies, currentReplies, createdAt, hasNewReplies, categoryId, lastReplyTime, bumpIndex, isDead
+        case number, stats, title, comment, imageUrl, boardAbv, replies, currentReplies, createdAt, hasNewReplies, categoryId, lastReplyTime, bumpIndex, boardPage, purgePosition, isDead
     }
 
     // Initializer from JSON
@@ -50,6 +52,8 @@ struct ThreadData: Codable {
                 self.lastReplyTime = firstPost["time"].int
             }
             self.bumpIndex = nil // This will be set based on position in board
+            self.boardPage = nil
+            self.purgePosition = nil
         } else {
             self.number = ""
             self.stats = "0/0"
@@ -60,6 +64,8 @@ struct ThreadData: Codable {
             self.createdAt = ""
             self.lastReplyTime = nil
             self.bumpIndex = nil
+            self.boardPage = nil
+            self.purgePosition = nil
         }
     }
 
@@ -76,10 +82,12 @@ struct ThreadData: Codable {
         self.categoryId = categoryId
         self.lastReplyTime = nil
         self.bumpIndex = nil
+        self.boardPage = nil
+        self.purgePosition = nil
     }
     
     // Extended initializer including all properties
-    init(number: String, stats: String, title: String, comment: String, imageUrl: String, boardAbv: String, replies: Int, currentReplies: Int? = nil, createdAt: String, hasNewReplies: Bool = false, categoryId: String? = nil, lastReplyTime: Int? = nil, bumpIndex: Int? = nil, isDead: Bool = false) {
+    init(number: String, stats: String, title: String, comment: String, imageUrl: String, boardAbv: String, replies: Int, currentReplies: Int? = nil, createdAt: String, hasNewReplies: Bool = false, categoryId: String? = nil, lastReplyTime: Int? = nil, bumpIndex: Int? = nil, boardPage: Int? = nil, purgePosition: Int? = nil, isDead: Bool = false) {
         self.number = number
         self.stats = stats
         self.title = title
@@ -93,6 +101,8 @@ struct ThreadData: Codable {
         self.categoryId = categoryId
         self.lastReplyTime = lastReplyTime
         self.bumpIndex = bumpIndex
+        self.boardPage = boardPage
+        self.purgePosition = purgePosition
         self.isDead = isDead
     }
 }
@@ -197,6 +207,10 @@ class boardTV: UITableViewController, UISearchBarDelegate, BottomToolbarSearchDi
     @objc private func thumbnailSizeDidChange() {
         tableView.reloadData()
     }
+
+    @objc private func threadUnreadCountDidChange() {
+        tableView.reloadData()
+    }
     
     // MARK: - Properties
     // This section contains properties and variables used throughout the class,
@@ -268,6 +282,10 @@ class boardTV: UITableViewController, UISearchBarDelegate, BottomToolbarSearchDi
         NotificationCenter.default.addObserver(self,
                                              selector: #selector(thumbnailSizeDidChange),
                                              name: .thumbnailSizeDidChange,
+                                             object: nil)
+        NotificationCenter.default.addObserver(self,
+                                             selector: #selector(threadUnreadCountDidChange),
+                                             name: ThreadReadStateManager.unreadCountDidChangeNotification,
                                              object: nil)
         
         print("=== boardTV viewDidLoad ===")
@@ -926,6 +944,8 @@ class boardTV: UITableViewController, UISearchBarDelegate, BottomToolbarSearchDi
                                 var thread = ThreadData(from: threadJson, boardAbv: self.boardAbv)
                                 // Set bump index based on position in board (0 = top/newest bump)
                                 thread.bumpIndex = (page - 1) * threads.count + index
+                                thread.boardPage = page
+                                thread.purgePosition = thread.bumpIndex.map { $0 + 1 }
                                 return thread.number.isEmpty ? nil : thread
                             }
     

--- a/Channer/ViewControllers/Board/boardTVCell.swift
+++ b/Channer/ViewControllers/Board/boardTVCell.swift
@@ -402,18 +402,28 @@ class boardTVCell: UITableViewCell {
     private func displayStats(for thread: ThreadData, isFavoritesView: Bool) -> String {
         let imageCount = thread.stats.split(separator: "/").last.map(String.init)
         let replyCount = thread.currentReplies ?? thread.replies
-        let statsText: String
+        var parts: [String] = []
 
         if let imageCount {
-            statsText = "\(replyCount)/\(imageCount)"
+            parts.append("\(replyCount)/\(imageCount)")
         } else {
-            statsText = thread.stats
+            parts.append(thread.stats)
         }
 
-        guard isFavoritesView else {
-            return statsText
+        let unreadCount = ThreadReadStateManager.shared.unreadCount(boardAbv: thread.boardAbv, threadNumber: thread.number)
+        if unreadCount > 0 {
+            parts.append("+\(unreadCount)")
         }
-        return statsText
+
+        if let page = thread.boardPage {
+            parts.append("p\(page)")
+        }
+
+        if let purgePosition = thread.purgePosition {
+            parts.append("#\(purgePosition)")
+        }
+
+        return parts.joined(separator: " ")
     }
     
     private func formatText(_ text: String) -> NSAttributedString {

--- a/Channer/ViewControllers/Home/HistoryManager.swift
+++ b/Channer/ViewControllers/Home/HistoryManager.swift
@@ -287,3 +287,186 @@ class ThreadScrollPositionManager {
         }
     }
 }
+
+struct ThreadReadState: Codable, Equatable {
+    let boardAbv: String
+    let threadNumber: String
+    var knownPostNumbers: [String]
+    var unreadPostNumbers: Set<String>
+    var lastReadPostNumber: String?
+    var boardPage: Int?
+    var purgePosition: Int?
+    var replyCount: Int?
+    var imageCount: Int?
+    var prunedPostNumbers: Set<String>
+    var updatedAt: Date
+}
+
+class ThreadReadStateManager {
+    static let shared = ThreadReadStateManager()
+    static let unreadCountDidChangeNotification = Notification.Name("ThreadReadStateUnreadCountDidChange")
+
+    private let statesKey = "threadReadStates"
+    private let maxStoredStates = 500
+    private let defaults: UserDefaults
+    private var states: [String: ThreadReadState] = [:]
+    private let lock = NSLock()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        loadStates()
+    }
+
+    @discardableResult
+    func updateThread(
+        boardAbv: String,
+        threadNumber: String,
+        postNumbers: [String],
+        boardPage: Int? = nil,
+        purgePosition: Int? = nil,
+        replyCount: Int? = nil,
+        imageCount: Int? = nil
+    ) -> ThreadReadState {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let stateKey = key(boardAbv: boardAbv, threadNumber: threadNumber)
+        var state = states[stateKey] ?? ThreadReadState(
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            knownPostNumbers: [],
+            unreadPostNumbers: [],
+            lastReadPostNumber: nil,
+            boardPage: nil,
+            purgePosition: nil,
+            replyCount: nil,
+            imageCount: nil,
+            prunedPostNumbers: [],
+            updatedAt: Date()
+        )
+
+        let known = Set(state.knownPostNumbers)
+        let newPosts = postNumbers.filter { !known.contains($0) }
+        if !state.knownPostNumbers.isEmpty {
+            state.unreadPostNumbers.formUnion(newPosts)
+        }
+
+        let currentPosts = Set(postNumbers)
+        state.unreadPostNumbers = state.unreadPostNumbers.intersection(currentPosts)
+        state.prunedPostNumbers = state.prunedPostNumbers.intersection(currentPosts)
+        state.knownPostNumbers = postNumbers
+        state.boardPage = boardPage ?? state.boardPage
+        state.purgePosition = purgePosition ?? state.purgePosition
+        state.replyCount = replyCount ?? state.replyCount
+        state.imageCount = imageCount ?? state.imageCount
+        state.updatedAt = Date()
+
+        states[stateKey] = state
+        pruneOldStatesIfNeeded()
+        persistStates()
+        postUnreadCountDidChange()
+        return state
+    }
+
+    func state(boardAbv: String, threadNumber: String) -> ThreadReadState? {
+        lock.lock()
+        defer { lock.unlock() }
+        return states[key(boardAbv: boardAbv, threadNumber: threadNumber)]
+    }
+
+    func markReadThrough(boardAbv: String, threadNumber: String, postNumber: String) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let stateKey = key(boardAbv: boardAbv, threadNumber: threadNumber)
+        guard var state = states[stateKey] else { return }
+
+        if let index = state.knownPostNumbers.firstIndex(of: postNumber) {
+            let readPosts = Set(state.knownPostNumbers.prefix(through: index))
+            state.unreadPostNumbers.subtract(readPosts)
+        } else {
+            state.unreadPostNumbers.remove(postNumber)
+        }
+
+        state.lastReadPostNumber = postNumber
+        state.updatedAt = Date()
+        states[stateKey] = state
+        persistStates()
+        postUnreadCountDidChange()
+    }
+
+    func markUnread(boardAbv: String, threadNumber: String, postNumbers: [String]) {
+        guard !postNumbers.isEmpty else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        let stateKey = key(boardAbv: boardAbv, threadNumber: threadNumber)
+        guard var state = states[stateKey] else { return }
+        state.unreadPostNumbers.formUnion(postNumbers)
+        state.unreadPostNumbers = state.unreadPostNumbers.intersection(Set(state.knownPostNumbers))
+        state.updatedAt = Date()
+        states[stateKey] = state
+        persistStates()
+        postUnreadCountDidChange()
+    }
+
+    func setPrunedPostNumbers(_ postNumbers: Set<String>, boardAbv: String, threadNumber: String) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let stateKey = key(boardAbv: boardAbv, threadNumber: threadNumber)
+        guard var state = states[stateKey] else { return }
+        state.prunedPostNumbers = postNumbers.intersection(Set(state.knownPostNumbers))
+        state.updatedAt = Date()
+        states[stateKey] = state
+        persistStates()
+    }
+
+    func unreadCount(boardAbv: String, threadNumber: String) -> Int {
+        state(boardAbv: boardAbv, threadNumber: threadNumber)?.unreadPostNumbers.count ?? 0
+    }
+
+    func totalUnreadCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return states.values.reduce(0) { $0 + $1.unreadPostNumbers.count }
+    }
+
+    private func key(boardAbv: String, threadNumber: String) -> String {
+        "\(boardAbv)/\(threadNumber)"
+    }
+
+    private func loadStates() {
+        guard let data = defaults.data(forKey: statesKey),
+              let savedStates = try? JSONDecoder().decode([String: ThreadReadState].self, from: data) else {
+            states = [:]
+            return
+        }
+        states = savedStates
+    }
+
+    private func persistStates() {
+        guard let data = try? JSONEncoder().encode(states) else { return }
+        defaults.set(data, forKey: statesKey)
+    }
+
+    private func pruneOldStatesIfNeeded() {
+        guard states.count > maxStoredStates else { return }
+
+        let keysToRemove = states
+            .sorted { $0.value.updatedAt < $1.value.updatedAt }
+            .prefix(states.count - maxStoredStates)
+            .map(\.key)
+
+        for key in keysToRemove {
+            states.removeValue(forKey: key)
+        }
+    }
+
+    private func postUnreadCountDidChange() {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: Self.unreadCountDidChangeNotification, object: nil)
+        }
+    }
+}

--- a/Channer/ViewControllers/Thread Replies/threadRepliesCell.swift
+++ b/Channer/ViewControllers/Thread Replies/threadRepliesCell.swift
@@ -201,6 +201,28 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
         return label
     }()
 
+    let newPosterBadge: UILabel = {
+        let label = UILabel()
+        label.text = "NEW IP"
+        label.font = UIFont.systemFont(ofSize: 11, weight: .bold)
+        label.textAlignment = .center
+        label.textColor = .white
+        label.backgroundColor = UIColor.systemIndigo
+        label.layer.cornerRadius = 8
+        label.layer.masksToBounds = true
+        label.isHidden = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    let lastReadLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.systemBlue
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     // Reply count label to show how many replies this post has received
     let replyCountLabel: UILabel = {
         let label = UILabel()
@@ -267,6 +289,8 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
         replyCountLabel.isHidden = true
         replyCountLabel.text = nil
         filterBadge.isHidden = true
+        newPosterBadge.isHidden = true
+        lastReadLineView.isHidden = true
         subjectLabel.isHidden = true
         subjectLabel.text = nil
         replyCountTrailingToFilterBadge?.isActive = false
@@ -390,6 +414,8 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
         contentView.addSubview(subjectLabel)
         // Reply bubble button removed - feature moved to long press menu
         contentView.addSubview(filterBadge)
+        contentView.addSubview(newPosterBadge)
+        contentView.addSubview(lastReadLineView)
         contentView.addSubview(replyCountLabel)
     }
 
@@ -414,6 +440,11 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
             customBackgroundView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
             customBackgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
 
+            lastReadLineView.leadingAnchor.constraint(equalTo: customBackgroundView.leadingAnchor, constant: 18),
+            lastReadLineView.trailingAnchor.constraint(equalTo: customBackgroundView.trailingAnchor, constant: -18),
+            lastReadLineView.topAnchor.constraint(equalTo: customBackgroundView.topAnchor, constant: 8),
+            lastReadLineView.heightAnchor.constraint(equalToConstant: 3),
+
             imageWidthConstraint!,
             imageHeightConstraint!,
             threadImage.leadingAnchor.constraint(equalTo: customBackgroundView.leadingAnchor, constant: sideInset),
@@ -432,6 +463,11 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
             filterBadge.trailingAnchor.constraint(equalTo: customBackgroundView.trailingAnchor, constant: -cornerInset),
             filterBadge.widthAnchor.constraint(equalToConstant: 80),
             filterBadge.heightAnchor.constraint(equalToConstant: 24),
+
+            newPosterBadge.topAnchor.constraint(equalTo: filterBadge.bottomAnchor, constant: 4),
+            newPosterBadge.trailingAnchor.constraint(equalTo: filterBadge.trailingAnchor),
+            newPosterBadge.widthAnchor.constraint(equalToConstant: 72),
+            newPosterBadge.heightAnchor.constraint(equalToConstant: 20),
 
             // Reply count label constraints - positioned at top right
             replyCountLabel.topAnchor.constraint(equalTo: customBackgroundView.topAnchor, constant: cornerInset),
@@ -477,7 +513,7 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
     }
 
     // MARK: - Configuration Method
-    func configure(withImage: Bool, text: NSAttributedString, boardNumber: String, isFiltered: Bool = false, replyCount: Int = 0, subject: String? = nil) {
+    func configure(withImage: Bool, text: NSAttributedString, boardNumber: String, isFiltered: Bool = false, replyCount: Int = 0, subject: String? = nil, isLastReadBoundary: Bool = false, isNewPosterAfterRead: Bool = false) {
         print("threadRepliesCell - Configure called with withImage: \(withImage)")
         threadImage.isHidden = !withImage
         replyText.isHidden = !withImage
@@ -519,6 +555,8 @@ class threadRepliesCell: UITableViewCell, VLCMediaPlayerDelegate {
         }
 
         boardReplyCount.text = boardNumber
+        lastReadLineView.isHidden = !isLastReadBoundary
+        newPosterBadge.isHidden = !isNewPosterAfterRead
 
         // Handle filtered content
         if isFiltered {

--- a/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
+++ b/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
@@ -423,6 +423,10 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     private var newPostCount: Int = 0
     /// UserDefaults key for new post behavior setting
     private let newPostBehaviorKey = "channer_new_post_behavior"
+    private var unreadPostNumbers = Set<String>()
+    private var firstUnreadPostNumber: String?
+    private var newPosterPostNumbers = Set<String>()
+    private var prunedPostNumbers = Set<String>()
 
     // MARK: - Jump to New Posts Button
     /// Floating button shown when new posts are detected
@@ -612,13 +616,14 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         /// - Uses `threadNumber` to identify the thread and calls `markThreadAsSeen` in `FavoritesManager`.
         /// This ensures that the thread is no longer highlighted as having new replies in the favorites view.
         if !threadNumber.isEmpty { // Use threadNumber instead of threadID
+            markThreadReadThroughVisibleContent()
             FavoritesManager.shared.markThreadAsSeen(threadID: threadNumber)
             FavoritesManager.shared.clearNewRepliesFlag(threadNumber: threadNumber)
             
             // Update application badge count
             DispatchQueue.main.async {
                 let notificationsEnabled = UserDefaults.standard.bool(forKey: "channer_notifications_enabled")
-                let badgeCount = notificationsEnabled ? NotificationManager.shared.getUnreadCount() : 0
+                let badgeCount = notificationsEnabled ? NotificationManager.shared.getUnreadCount() + ThreadReadStateManager.shared.totalUnreadCount() : 0
                 UIApplication.shared.applicationIconBadgeNumber = badgeCount
             }
         }
@@ -1120,13 +1125,21 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
               scrollToPostNumber == nil,
               !threadNumber.isEmpty,
               !boardAbv.isEmpty,
-              tableView.numberOfRows(inSection: 0) > 0,
-              let position = ThreadScrollPositionManager.shared.position(boardAbv: boardAbv, threadNumber: threadNumber) else {
+              tableView.numberOfRows(inSection: 0) > 0 else {
             return
         }
 
         hasRestoredSavedScrollPosition = true
         tableView.layoutIfNeeded()
+
+        guard let position = ThreadScrollPositionManager.shared.position(boardAbv: boardAbv, threadNumber: threadNumber) else {
+            if let firstUnreadPostNumber,
+               let index = threadBoardReplyNumber.firstIndex(of: firstUnreadPostNumber),
+               index < tableView.numberOfRows(inSection: 0) {
+                tableView.scrollToRow(at: IndexPath(row: index, section: 0), at: .top, animated: false)
+            }
+            return
+        }
 
         if let index = restoreIndex(for: position) {
             let indexPath = IndexPath(row: index, section: 0)
@@ -1346,6 +1359,12 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
                 },
                 ThreadMoreOption(title: "Bottom", subtitle: "Jump to the newest loaded reply", systemImageName: "arrow.down.to.line") { [weak self] in
                     self?.down()
+                },
+                ThreadMoreOption(title: "Prune Read Replies", subtitle: "Hide replies already marked read", systemImageName: "scissors") { [weak self] in
+                    self?.pruneReadReplies()
+                },
+                ThreadMoreOption(title: "Restore Pruned Replies", subtitle: "Show replies hidden by pruning", systemImageName: "arrow.uturn.backward") { [weak self] in
+                    self?.restorePrunedReplies()
                 },
                 ThreadMoreOption(title: showSpoilers ? "Hide Spoilers" : "Show Spoilers", subtitle: "Toggle spoiler visibility", systemImageName: showSpoilers ? "eye.slash" : "eye") { [weak self] in
                     self?.toggleSpoilers()
@@ -1606,11 +1625,12 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     // MARK: - Table View Data Source Methods
     /// Methods required to display data in the table view
     private func actualIndex(for indexPath: IndexPath) -> Int? {
-        guard isSearchActive && !searchText.isEmpty else { return indexPath.row }
-
         var visibleIndex = 0
         for dataIndex in 0..<threadReplies.count {
-            if !searchFilteredIndices.contains(dataIndex) {
+            let postNumber = dataIndex < threadBoardReplyNumber.count ? threadBoardReplyNumber[dataIndex] : nil
+            let isPruned = postNumber.map { prunedPostNumbers.contains($0) } ?? false
+            let isSearchFiltered = isSearchActive && !searchText.isEmpty && searchFilteredIndices.contains(dataIndex)
+            if !isPruned && !isSearchFiltered {
                 if visibleIndex == indexPath.row {
                     return dataIndex
                 }
@@ -1632,10 +1652,17 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         
         // If search is active, only count unfiltered rows
         if isSearchActive && !searchText.isEmpty {
-            return threadReplies.count - searchFilteredIndices.count
+            return (0..<threadReplies.count).filter { index in
+                let postNumber = index < threadBoardReplyNumber.count ? threadBoardReplyNumber[index] : nil
+                let isPruned = postNumber.map { prunedPostNumbers.contains($0) } ?? false
+                return !isPruned && !searchFilteredIndices.contains(index)
+            }.count
         }
         
-        return threadReplies.count
+        return threadReplies.indices.filter { index in
+            let postNumber = index < threadBoardReplyNumber.count ? threadBoardReplyNumber[index] : nil
+            return !(postNumber.map { prunedPostNumbers.contains($0) } ?? false)
+        }.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -1702,6 +1729,8 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
 
             // Pass subject only for the first cell (OP)
             let subject = actualIndex == 0 ? threadSubject : nil
+            let isLastReadBoundary = firstUnreadPostNumber == boardNumber
+            let isNewPosterAfterRead = newPosterPostNumbers.contains(boardNumber)
 
             // Configure the cell with text and other details
             cell.configure(withImage: hasImage,
@@ -1709,7 +1738,9 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
                            boardNumber: boardNumber,
                            isFiltered: isFiltered,
                            replyCount: replyCount,
-                           subject: subject)
+                           subject: subject,
+                           isLastReadBoundary: isLastReadBoundary,
+                           isNewPosterAfterRead: isNewPosterAfterRead)
             
             // Set the attributed text based on whether the cell has an image
             if hasImage {
@@ -2207,12 +2238,102 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
 
         // Finalize thread structure
         structureThreadReplies()
+        updateReadStateFromLoadedPosts()
 
         // Check for new replies to watched posts
         checkWatchedPostsForNewReplies()
 
         // Check watch rules for new matches
         checkWatchRulesForNewMatches()
+    }
+
+    private func updateReadStateFromLoadedPosts() {
+        guard !boardAbv.isEmpty, !threadNumber.isEmpty else { return }
+
+        let state = ThreadReadStateManager.shared.updateThread(
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            postNumbers: threadBoardReplyNumber,
+            replyCount: replyCount,
+            imageCount: totalImagesInThread
+        )
+
+        unreadPostNumbers = state.unreadPostNumbers
+        prunedPostNumbers = state.prunedPostNumbers
+        firstUnreadPostNumber = threadBoardReplyNumber.first { unreadPostNumbers.contains($0) }
+        updateNewPosterMarkers()
+        updateUnreadChrome()
+    }
+
+    private func updateNewPosterMarkers() {
+        newPosterPostNumbers.removeAll()
+        guard let firstUnreadPostNumber,
+              let firstUnreadIndex = threadBoardReplyNumber.firstIndex(of: firstUnreadPostNumber) else {
+            return
+        }
+
+        var seenPosterIds = Set<String>()
+        for index in 0..<postMetadataList.count {
+            guard let posterId = postMetadataList[index].posterId, !posterId.isEmpty else { continue }
+            if index >= firstUnreadIndex && !seenPosterIds.contains(posterId) {
+                newPosterPostNumbers.insert(postMetadataList[index].postNumber)
+            }
+            seenPosterIds.insert(posterId)
+        }
+    }
+
+    private func updateUnreadChrome() {
+        let unreadCount = unreadPostNumbers.count
+        if unreadCount > 0 {
+            title = "(\(unreadCount)) /\(boardAbv)/ \(threadNumber)"
+        } else if title?.isEmpty ?? true {
+            title = "/\(boardAbv)/ \(threadNumber)"
+        }
+    }
+
+    private func markThreadReadThroughVisibleContent() {
+        guard !boardAbv.isEmpty, !threadNumber.isEmpty else { return }
+
+        let visibleRows = tableView.indexPathsForVisibleRows ?? []
+        let lastVisibleActualIndex = visibleRows
+            .compactMap { actualIndex(for: $0) }
+            .max()
+
+        let fallbackIndex = threadBoardReplyNumber.indices.last
+        guard let index = lastVisibleActualIndex ?? fallbackIndex,
+              index < threadBoardReplyNumber.count else { return }
+
+        let postNumber = threadBoardReplyNumber[index]
+        ThreadReadStateManager.shared.markReadThrough(
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            postNumber: postNumber
+        )
+    }
+
+    private func pruneReadReplies() {
+        guard !threadBoardReplyNumber.isEmpty else { return }
+        let lastReadPostNumber = ThreadReadStateManager.shared.state(boardAbv: boardAbv, threadNumber: threadNumber)?.lastReadPostNumber
+        guard let lastReadPostNumber,
+              let lastReadIndex = threadBoardReplyNumber.firstIndex(of: lastReadPostNumber),
+              lastReadIndex > 1 else {
+            showToast(message: "No read replies to prune")
+            return
+        }
+
+        let unread = unreadPostNumbers
+        let readReplies = threadBoardReplyNumber[1...lastReadIndex].filter { !unread.contains($0) }
+        prunedPostNumbers.formUnion(readReplies)
+        ThreadReadStateManager.shared.setPrunedPostNumbers(prunedPostNumbers, boardAbv: boardAbv, threadNumber: threadNumber)
+        debugReloadData(context: "Prune read replies")
+        showToast(message: "Pruned \(readReplies.count) read replies")
+    }
+
+    private func restorePrunedReplies() {
+        guard !prunedPostNumbers.isEmpty else { return }
+        prunedPostNumbers.removeAll()
+        ThreadReadStateManager.shared.setPrunedPostNumbers([], boardAbv: boardAbv, threadNumber: threadNumber)
+        debugReloadData(context: "Restore pruned replies")
     }
 
     /// Checks watched posts for new replies and creates notifications

--- a/Channer/iPad/threadRepliesCV.swift
+++ b/Channer/iPad/threadRepliesCV.swift
@@ -153,6 +153,10 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
     /// Thread subject from OP
     var threadSubject: String = ""
     private var hasRestoredSavedScrollPosition = false
+    private var unreadPostNumbers = Set<String>()
+    private var firstUnreadPostNumber: String?
+    private var newPosterPostNumbers = Set<String>()
+    private var prunedPostNumbers = Set<String>()
 
     private lazy var postInfoDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -374,6 +378,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
             
         }
         
+        updateReadStateFromLoadedPosts()
         collectionView?.reloadData()
         restoreScrollPositionIfNeeded()
         checkWatchRulesForNewMatches()
@@ -382,6 +387,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         saveCurrentScrollPosition()
+        markThreadReadThroughVisibleContent()
     }
 
     deinit {
@@ -436,13 +442,21 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
               !threadNumber.isEmpty,
               !boardAbv.isEmpty,
               let collectionView = collectionView,
-              collectionView.numberOfItems(inSection: 0) > 0,
-              let position = ThreadScrollPositionManager.shared.position(boardAbv: boardAbv, threadNumber: threadNumber) else {
+              collectionView.numberOfItems(inSection: 0) > 0 else {
             return
         }
 
         hasRestoredSavedScrollPosition = true
         collectionView.layoutIfNeeded()
+
+        guard let position = ThreadScrollPositionManager.shared.position(boardAbv: boardAbv, threadNumber: threadNumber) else {
+            if let firstUnreadPostNumber,
+               let index = threadBoardReplyNumber.firstIndex(of: firstUnreadPostNumber),
+               index < collectionView.numberOfItems(inSection: 0) {
+                collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .top, animated: false)
+            }
+            return
+        }
 
         if let index = restoreIndex(for: position, itemCount: collectionView.numberOfItems(inSection: 0)) {
             let indexPath = IndexPath(item: index, section: 0)
@@ -473,6 +487,54 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
         let minY = -collectionView.adjustedContentInset.top
         let maxY = max(minY, collectionView.contentSize.height - collectionView.bounds.height + collectionView.adjustedContentInset.bottom)
         return min(max(proposedY, minY), maxY)
+    }
+
+    private func updateReadStateFromLoadedPosts() {
+        guard !boardAbv.isEmpty, !threadNumber.isEmpty, !forBoardThread else { return }
+
+        let state = ThreadReadStateManager.shared.updateThread(
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            postNumbers: threadBoardReplyNumber
+        )
+        unreadPostNumbers = state.unreadPostNumbers
+        prunedPostNumbers = state.prunedPostNumbers
+        firstUnreadPostNumber = threadBoardReplyNumber.first { unreadPostNumbers.contains($0) }
+        updateNewPosterMarkers()
+        if !unreadPostNumbers.isEmpty {
+            title = "(\(unreadPostNumbers.count)) /\(boardAbv)/ \(threadNumber)"
+        }
+    }
+
+    private func updateNewPosterMarkers() {
+        newPosterPostNumbers.removeAll()
+        guard let firstUnreadPostNumber,
+              let firstUnreadIndex = threadBoardReplyNumber.firstIndex(of: firstUnreadPostNumber) else {
+            return
+        }
+
+        var seenPosterIds = Set<String>()
+        for index in 0..<threadRepliesPosterIds.count {
+            guard let posterId = threadRepliesPosterIds[index], !posterId.isEmpty else { continue }
+            if index >= firstUnreadIndex && !seenPosterIds.contains(posterId), index < threadBoardReplyNumber.count {
+                newPosterPostNumbers.insert(threadBoardReplyNumber[index])
+            }
+            seenPosterIds.insert(posterId)
+        }
+    }
+
+    private func markThreadReadThroughVisibleContent() {
+        guard !forBoardThread, !boardAbv.isEmpty, !threadNumber.isEmpty,
+              let lastVisibleIndex = collectionView?.indexPathsForVisibleItems.map(\.item).max(),
+              lastVisibleIndex < threadBoardReplyNumber.count else {
+            return
+        }
+
+        ThreadReadStateManager.shared.markReadThrough(
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            postNumber: threadBoardReplyNumber[lastVisibleIndex]
+        )
     }
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
@@ -678,7 +740,11 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
 
         // Set post number
         let boardNumber = threadBoardReplyNumber[indexPath.row]
-        cell.boardReplyCount.text = boardNumber
+        let newPosterSuffix = newPosterPostNumbers.contains(boardNumber) ? "  NEW IP" : ""
+        cell.boardReplyCount.text = "\(boardNumber)\(newPosterSuffix)"
+        cell.contentView.layer.borderWidth = firstUnreadPostNumber == boardNumber ? 3 : 0
+        cell.contentView.layer.borderColor = UIColor.systemBlue.cgColor
+        cell.contentView.layer.cornerRadius = 12
 
         // Set reply count (number of replies to this post)
         let replyCount = threadBoardReplies[boardNumber]?.count ?? 0


### PR DESCRIPTION
## Summary
- Added persistent per-thread read state to track unread replies, last-read position, and reply pruning state.
- Wired thread updates into background monitoring, app badge totals, board stats, and thread navigation recovery.
- Added UI signals for unread boundaries, new poster markers, purge/page stats, and manual prune/restore actions.

## Testing
- `./build.sh` passed after allowing Xcode to resolve Swift package dependencies.
- `git diff --check` passed.
- Verified the new thread state paths compile across app launch, background refresh, board list, and thread reply screens.