### PR TITLE
Add XT-style media controls and gallery support

### DIFF
--- a/Channer/Utilities/AdvancedFilter.swift
+++ b/Channer/Utilities/AdvancedFilter.swift
@@ -239,6 +239,55 @@ struct PostMetadata: Codable {
     let imageExtension: String?
     let imageName: String?
     let fileHash: String?
+    let isSpoiler: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case postNumber, comment, posterId, tripCode, countryCode, countryName, timestamp, imageUrl, imageExtension, imageName, fileHash, isSpoiler
+    }
+
+    init(
+        postNumber: String,
+        comment: String,
+        posterId: String?,
+        tripCode: String?,
+        countryCode: String?,
+        countryName: String?,
+        timestamp: Int?,
+        imageUrl: String?,
+        imageExtension: String?,
+        imageName: String?,
+        fileHash: String? = nil,
+        isSpoiler: Bool = false
+    ) {
+        self.postNumber = postNumber
+        self.comment = comment
+        self.posterId = posterId
+        self.tripCode = tripCode
+        self.countryCode = countryCode
+        self.countryName = countryName
+        self.timestamp = timestamp
+        self.imageUrl = imageUrl
+        self.imageExtension = imageExtension
+        self.imageName = imageName
+        self.fileHash = fileHash
+        self.isSpoiler = isSpoiler
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        postNumber = try container.decode(String.self, forKey: .postNumber)
+        comment = try container.decode(String.self, forKey: .comment)
+        posterId = try container.decodeIfPresent(String.self, forKey: .posterId)
+        tripCode = try container.decodeIfPresent(String.self, forKey: .tripCode)
+        countryCode = try container.decodeIfPresent(String.self, forKey: .countryCode)
+        countryName = try container.decodeIfPresent(String.self, forKey: .countryName)
+        timestamp = try container.decodeIfPresent(Int.self, forKey: .timestamp)
+        imageUrl = try container.decodeIfPresent(String.self, forKey: .imageUrl)
+        imageExtension = try container.decodeIfPresent(String.self, forKey: .imageExtension)
+        imageName = try container.decodeIfPresent(String.self, forKey: .imageName)
+        fileHash = try container.decodeIfPresent(String.self, forKey: .fileHash)
+        isSpoiler = try container.decodeIfPresent(Bool.self, forKey: .isSpoiler) ?? false
+    }
 
     /// Checks if post has an attachment
     var hasAttachment: Bool {

--- a/Channer/Utilities/MediaSettings.swift
+++ b/Channer/Utilities/MediaSettings.swift
@@ -3,30 +3,255 @@ import Foundation
 struct MediaSettings {
     static let defaultMutedKey = "channer_media_default_muted"
     static let videoPreviewInDownloadsKey = "channer_video_preview_in_downloads"
+    static let defaultVideoVolumeKey = "channer_media_default_video_volume"
+    static let webMMetadataKey = "channer_media_webm_metadata_enabled"
+    static let revealSpoilerThumbnailsKey = "channer_media_reveal_spoiler_thumbnails"
+    static let replaceGIFThumbnailsKey = "channer_media_replace_gif_thumbnails"
+    static let replaceJPGThumbnailsKey = "channer_media_replace_jpg_thumbnails"
+    static let replacePNGThumbnailsKey = "channer_media_replace_png_thumbnails"
+    static let replaceVideoThumbnailsKey = "channer_media_replace_video_thumbnails"
+    static let hidePostsWithoutImagesKey = "channer_media_hide_posts_without_images"
+    static let hideAllImagesKey = "channer_media_hide_all_images"
+    static let mouseWheelVolumeKey = "channer_media_mouse_wheel_volume"
+    static let soundPostsKey = "channer_media_sound_posts_enabled"
+    static let pdfInGalleryKey = "channer_media_pdf_in_gallery"
+
+    private static func bool(for key: String, default defaultValue: Bool) -> Bool {
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: key) == nil {
+            defaults.set(defaultValue, forKey: key)
+        }
+        return defaults.bool(forKey: key)
+    }
+
+    private static func setBool(_ value: Bool, for key: String) {
+        UserDefaults.standard.set(value, forKey: key)
+    }
 
     static var defaultMuted: Bool {
         get {
-            let defaults = UserDefaults.standard
-            if defaults.object(forKey: defaultMutedKey) == nil {
-                defaults.set(true, forKey: defaultMutedKey)
-            }
-            return defaults.bool(forKey: defaultMutedKey)
+            bool(for: defaultMutedKey, default: true)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: defaultMutedKey)
+            setBool(newValue, for: defaultMutedKey)
         }
     }
 
     static var videoPreviewInDownloads: Bool {
         get {
-            let defaults = UserDefaults.standard
-            if defaults.object(forKey: videoPreviewInDownloadsKey) == nil {
-                defaults.set(false, forKey: videoPreviewInDownloadsKey)
-            }
-            return defaults.bool(forKey: videoPreviewInDownloadsKey)
+            bool(for: videoPreviewInDownloadsKey, default: false)
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: videoPreviewInDownloadsKey)
+            setBool(newValue, for: videoPreviewInDownloadsKey)
         }
+    }
+
+    static var defaultVideoVolume: Float {
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: defaultVideoVolumeKey) == nil {
+                defaults.set(0.5, forKey: defaultVideoVolumeKey)
+            }
+            return max(0, min(1, defaults.float(forKey: defaultVideoVolumeKey)))
+        }
+        set {
+            UserDefaults.standard.set(max(0, min(1, newValue)), forKey: defaultVideoVolumeKey)
+        }
+    }
+
+    static var defaultVLCVolume: Int32 {
+        Int32((defaultVideoVolume * 100).rounded())
+    }
+
+    static var webMMetadataEnabled: Bool {
+        get { bool(for: webMMetadataKey, default: true) }
+        set { setBool(newValue, for: webMMetadataKey) }
+    }
+
+    static var revealSpoilerThumbnails: Bool {
+        get { bool(for: revealSpoilerThumbnailsKey, default: false) }
+        set { setBool(newValue, for: revealSpoilerThumbnailsKey) }
+    }
+
+    static var replaceGIFThumbnails: Bool {
+        get { bool(for: replaceGIFThumbnailsKey, default: false) }
+        set { setBool(newValue, for: replaceGIFThumbnailsKey) }
+    }
+
+    static var replaceJPGThumbnails: Bool {
+        get { bool(for: replaceJPGThumbnailsKey, default: false) }
+        set { setBool(newValue, for: replaceJPGThumbnailsKey) }
+    }
+
+    static var replacePNGThumbnails: Bool {
+        get { bool(for: replacePNGThumbnailsKey, default: false) }
+        set { setBool(newValue, for: replacePNGThumbnailsKey) }
+    }
+
+    static var replaceVideoThumbnails: Bool {
+        get { bool(for: replaceVideoThumbnailsKey, default: false) }
+        set { setBool(newValue, for: replaceVideoThumbnailsKey) }
+    }
+
+    static var hidePostsWithoutImages: Bool {
+        get { bool(for: hidePostsWithoutImagesKey, default: false) }
+        set { setBool(newValue, for: hidePostsWithoutImagesKey) }
+    }
+
+    static var hideAllImages: Bool {
+        get { bool(for: hideAllImagesKey, default: false) }
+        set { setBool(newValue, for: hideAllImagesKey) }
+    }
+
+    static var mouseWheelVolumeEnabled: Bool {
+        get { bool(for: mouseWheelVolumeKey, default: true) }
+        set { setBool(newValue, for: mouseWheelVolumeKey) }
+    }
+
+    static var soundPostsEnabled: Bool {
+        get { bool(for: soundPostsKey, default: false) }
+        set { setBool(newValue, for: soundPostsKey) }
+    }
+
+    static var pdfInGallery: Bool {
+        get { bool(for: pdfInGalleryKey, default: false) }
+        set { setBool(newValue, for: pdfInGalleryKey) }
+    }
+
+    static func isSupportedGalleryURL(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        if ext == "pdf" {
+            return pdfInGallery
+        }
+        return ["jpg", "jpeg", "png", "gif", "webm", "mp4"].contains(ext)
+    }
+
+    static func shouldReplaceThumbnail(forExtension ext: String) -> Bool {
+        switch ext.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: ".")) {
+        case "jpg", "jpeg":
+            return replaceJPGThumbnails
+        case "png":
+            return replacePNGThumbnails
+        case "gif":
+            return replaceGIFThumbnails
+        case "webm", "mp4":
+            return replaceVideoThumbnails
+        default:
+            return false
+        }
+    }
+
+    static func thumbnailURL(from raw: String, useHighQuality: Bool, isSpoiler: Bool = false) -> URL? {
+        if isSpoiler && !revealSpoilerThumbnails {
+            return URL(string: "https://s.4cdn.org/image/spoiler.png")
+        }
+
+        guard let url = URL(string: raw) else { return nil }
+        let ext = url.pathExtension.lowercased()
+
+        if ext == "pdf" {
+            return nil
+        }
+
+        if ext == "webm" || ext == "mp4" {
+            return suffixThumbnailURL(from: raw, replacingExtension: ext)
+        }
+
+        if useHighQuality || shouldReplaceThumbnail(forExtension: ext) {
+            return url
+        }
+
+        return suffixThumbnailURL(from: raw, replacingExtension: ext) ?? url
+    }
+
+    private static func suffixThumbnailURL(from raw: String, replacingExtension ext: String) -> URL? {
+        let comps = raw.split(separator: "/")
+        guard let last = comps.last, let dot = last.firstIndex(of: ".") else {
+            return URL(string: raw)
+        }
+        let filename = String(last[..<dot]) + "s.jpg"
+        return URL(string: raw.replacingOccurrences(of: String(last), with: filename))
+    }
+
+    static func soundPostURL(from filename: String?) -> URL? {
+        guard soundPostsEnabled,
+              let filename = filename,
+              let range = filename.range(of: #"\[sound=([^\]]+)\]"#, options: .regularExpression) else {
+            return nil
+        }
+
+        let token = String(filename[range])
+            .replacingOccurrences(of: "[sound=", with: "")
+            .replacingOccurrences(of: "]", with: "")
+
+        if let url = URL(string: token), url.scheme != nil {
+            return url
+        }
+        return URL(string: "https://\(token)")
+    }
+}
+
+final class WebMMetadataFetcher {
+    static let shared = WebMMetadataFetcher()
+
+    private let queue = DispatchQueue(label: "com.channer.webmMetadata", qos: .utility)
+    private var cache: [URL: String?] = [:]
+
+    private init() {}
+
+    func fetchTitle(for url: URL, completion: @escaping (String?) -> Void) {
+        queue.async {
+            if self.cache.keys.contains(url) {
+                let cached = self.cache[url] ?? nil
+                DispatchQueue.main.async { completion(cached) }
+                return
+            }
+
+            var request = URLRequest(url: url)
+            request.setValue("bytes=0-9999", forHTTPHeaderField: "Range")
+
+            URLSession.shared.dataTask(with: request) { data, _, _ in
+                let title = data.flatMap { Self.parseTitle(from: [UInt8]($0)) }
+                self.queue.async {
+                    self.cache[url] = title
+                    DispatchQueue.main.async { completion(title) }
+                }
+            }.resume()
+        }
+    }
+
+    private static func parseTitle(from bytes: [UInt8]) -> String? {
+        var index = 0
+
+        func readInt() -> Int? {
+            guard index < bytes.count else { return nil }
+            var value = Int(bytes[index])
+            index += 1
+            var length = 0
+            while length < 8 && value < (0x80 >> length) {
+                length += 1
+            }
+            value ^= (0x80 >> length)
+            while length > 0 && index < bytes.count {
+                value = (value << 8) ^ Int(bytes[index])
+                index += 1
+                length -= 1
+            }
+            return value
+        }
+
+        while index < bytes.count {
+            guard let element = readInt(), let size = readInt() else { return nil }
+            if element == 0x3BA9 {
+                guard index + size <= bytes.count else { return nil }
+                let titleBytes = Array(bytes[index..<(index + size)])
+                return String(data: Data(titleBytes), encoding: .utf8)
+            }
+            if element != 0x8538067 && element != 0x549A966 {
+                index = min(bytes.count, index + size)
+            }
+        }
+
+        return nil
     }
 }

--- a/Channer/ViewControllers/Home/settings.swift
+++ b/Channer/ViewControllers/Home/settings.swift
@@ -3376,6 +3376,10 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
     private enum Section: Int, CaseIterable {
         case mode
         case battery
+        case thumbnailControls
+        case visibility
+        case sound
+        case gallery
         case perBoard
 
         var title: String {
@@ -3384,6 +3388,14 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
                 return "Network"
             case .battery:
                 return "Battery"
+            case .thumbnailControls:
+                return "Thumbnail Replacement"
+            case .visibility:
+                return "Thread Media"
+            case .sound:
+                return "Video and Sound"
+            case .gallery:
+                return "Gallery"
             case .perBoard:
                 return "Per-board Rules"
             }
@@ -3393,6 +3405,30 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
     private enum BatteryRow: Int, CaseIterable {
         case pauseLowPower
         case minimumBattery
+    }
+
+    private enum ThumbnailRow: Int, CaseIterable {
+        case revealSpoilers
+        case replaceJPG
+        case replacePNG
+        case replaceGIF
+        case replaceVideos
+    }
+
+    private enum VisibilityRow: Int, CaseIterable {
+        case hidePostsWithoutImages
+        case hideAllImages
+    }
+
+    private enum SoundRow: Int, CaseIterable {
+        case defaultVolume
+        case mouseWheelVolume
+        case soundPosts
+        case webMMetadata
+    }
+
+    private enum GalleryRow: Int, CaseIterable {
+        case pdfInGallery
     }
 
     private let tableView = UITableView(frame: .zero, style: .insetGrouped)
@@ -3436,6 +3472,14 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
             return 1
         case .battery:
             return BatteryRow.allCases.count
+        case .thumbnailControls:
+            return ThumbnailRow.allCases.count
+        case .visibility:
+            return VisibilityRow.allCases.count
+        case .sound:
+            return SoundRow.allCases.count
+        case .gallery:
+            return GalleryRow.allCases.count
         case .perBoard:
             return 1
         }
@@ -3452,6 +3496,14 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
             return "Prefetches thumbnails to make scrolling smoother."
         case .battery:
             return "Prefetching pauses when Low Power Mode is enabled or the battery is below the selected threshold."
+        case .thumbnailControls:
+            return "Matches 4chan XT media controls: spoiler reveal and replacing thumbnails with full originals or videos."
+        case .visibility:
+            return "Hide text-only posts or hide media thumbnails without losing post text."
+        case .sound:
+            return "WebM metadata fetches the title from the first bytes of the file. Sound posts load URLs from [sound=] filenames."
+        case .gallery:
+            return "PDF files appear in the media gallery only when enabled."
         case .perBoard:
             return "Overrides apply to both board and thread views."
         }
@@ -3496,6 +3548,45 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
                 cell.accessoryType = .disclosureIndicator
                 cell.selectionStyle = .default
             }
+        case .thumbnailControls:
+            guard let row = ThumbnailRow(rawValue: indexPath.row) else { return cell }
+            switch row {
+            case .revealSpoilers:
+                configureSwitchCell(cell, title: "Reveal Spoiler Thumbnails", isOn: MediaSettings.revealSpoilerThumbnails, action: #selector(revealSpoilerThumbnailsChanged(_:)))
+            case .replaceJPG:
+                configureSwitchCell(cell, title: "Replace JPG Thumbnails", isOn: MediaSettings.replaceJPGThumbnails, action: #selector(replaceJPGThumbnailsChanged(_:)))
+            case .replacePNG:
+                configureSwitchCell(cell, title: "Replace PNG Thumbnails", isOn: MediaSettings.replacePNGThumbnails, action: #selector(replacePNGThumbnailsChanged(_:)))
+            case .replaceGIF:
+                configureSwitchCell(cell, title: "Replace GIF Thumbnails", isOn: MediaSettings.replaceGIFThumbnails, action: #selector(replaceGIFThumbnailsChanged(_:)))
+            case .replaceVideos:
+                configureSwitchCell(cell, title: "Replace Video Thumbnails", isOn: MediaSettings.replaceVideoThumbnails, action: #selector(replaceVideoThumbnailsChanged(_:)))
+            }
+        case .visibility:
+            guard let row = VisibilityRow(rawValue: indexPath.row) else { return cell }
+            switch row {
+            case .hidePostsWithoutImages:
+                configureSwitchCell(cell, title: "Hide Posts Without Images", isOn: MediaSettings.hidePostsWithoutImages, action: #selector(hidePostsWithoutImagesChanged(_:)))
+            case .hideAllImages:
+                configureSwitchCell(cell, title: "Hide All Images", isOn: MediaSettings.hideAllImages, action: #selector(hideAllImagesChanged(_:)))
+            }
+        case .sound:
+            guard let row = SoundRow(rawValue: indexPath.row) else { return cell }
+            switch row {
+            case .defaultVolume:
+                cell.textLabel?.text = "Default Video Volume"
+                cell.detailTextLabel?.text = "\(Int((MediaSettings.defaultVideoVolume * 100).rounded()))%"
+                cell.accessoryType = .disclosureIndicator
+                cell.selectionStyle = .default
+            case .mouseWheelVolume:
+                configureSwitchCell(cell, title: "Mouse-wheel Volume", isOn: MediaSettings.mouseWheelVolumeEnabled, action: #selector(mouseWheelVolumeChanged(_:)))
+            case .soundPosts:
+                configureSwitchCell(cell, title: "Enable Sound Posts", isOn: MediaSettings.soundPostsEnabled, action: #selector(soundPostsChanged(_:)))
+            case .webMMetadata:
+                configureSwitchCell(cell, title: "WebM Metadata", isOn: MediaSettings.webMMetadataEnabled, action: #selector(webMMetadataChanged(_:)))
+            }
+        case .gallery:
+            configureSwitchCell(cell, title: "PDF in Gallery", isOn: MediaSettings.pdfInGallery, action: #selector(pdfInGalleryChanged(_:)))
         case .perBoard:
             cell.textLabel?.text = "Manage Per-board Rules"
             let count = manager.boardOverrideCount()
@@ -3521,15 +3612,43 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
                let cell = tableView.cellForRow(at: indexPath) {
                 presentBatteryPicker(from: cell)
             }
+        case .sound:
+            if SoundRow(rawValue: indexPath.row) == .defaultVolume,
+               let cell = tableView.cellForRow(at: indexPath) {
+                presentVolumePicker(from: cell)
+            }
+        case .thumbnailControls, .visibility, .gallery:
+            break
         case .perBoard:
             let perBoardVC = MediaPrefetchBoardRulesViewController()
             navigationController?.pushViewController(perBoardVC, animated: true)
         }
     }
 
+    private func configureSwitchCell(_ cell: UITableViewCell, title: String, isOn: Bool, action: Selector) {
+        cell.textLabel?.text = title
+        let toggle = UISwitch()
+        toggle.isOn = isOn
+        toggle.addTarget(self, action: action, for: .valueChanged)
+        cell.accessoryView = toggle
+        cell.selectionStyle = .none
+    }
+
     @objc private func pauseOnLowPowerChanged(_ sender: UISwitch) {
         manager.pauseOnLowPowerMode = sender.isOn
     }
+
+    @objc private func revealSpoilerThumbnailsChanged(_ sender: UISwitch) { MediaSettings.revealSpoilerThumbnails = sender.isOn }
+    @objc private func replaceJPGThumbnailsChanged(_ sender: UISwitch) { MediaSettings.replaceJPGThumbnails = sender.isOn }
+    @objc private func replacePNGThumbnailsChanged(_ sender: UISwitch) { MediaSettings.replacePNGThumbnails = sender.isOn }
+    @objc private func replaceGIFThumbnailsChanged(_ sender: UISwitch) { MediaSettings.replaceGIFThumbnails = sender.isOn }
+    @objc private func replaceVideoThumbnailsChanged(_ sender: UISwitch) { MediaSettings.replaceVideoThumbnails = sender.isOn }
+    @objc private func hidePostsWithoutImagesChanged(_ sender: UISwitch) { MediaSettings.hidePostsWithoutImages = sender.isOn }
+    @objc private func hideAllImagesChanged(_ sender: UISwitch) { MediaSettings.hideAllImages = sender.isOn }
+    @objc private func mouseWheelVolumeChanged(_ sender: UISwitch) { MediaSettings.mouseWheelVolumeEnabled = sender.isOn }
+    @objc private func soundPostsChanged(_ sender: UISwitch) { MediaSettings.soundPostsEnabled = sender.isOn }
+    @objc private func webMMetadataChanged(_ sender: UISwitch) { MediaSettings.webMMetadataEnabled = sender.isOn }
+    @objc private func pdfInGalleryChanged(_ sender: UISwitch) { MediaSettings.pdfInGallery = sender.isOn }
 
     private func presentModePicker(from cell: UITableViewCell) {
         let alert = UIAlertController(title: "Prefetch Mode", message: "Choose when to prefetch media", preferredStyle: .actionSheet)
@@ -3579,6 +3698,25 @@ final class MediaPrefetchSettingsViewController: UIViewController, UITableViewDe
             popover.channerAnchor(in: self, sourceView: cell, sourceRect: cell.bounds, permittedArrowDirections: [.up, .down])
         }
 
+        present(alert, animated: true)
+    }
+
+    private func presentVolumePicker(from cell: UITableViewCell) {
+        let alert = UIAlertController(title: "Default Video Volume", message: "Choose the volume used when videos start unmuted", preferredStyle: .actionSheet)
+        for value in [0, 25, 50, 75, 100] {
+            let action = UIAlertAction(title: "\(value)%", style: .default) { [weak self] _ in
+                MediaSettings.defaultVideoVolume = Float(value) / 100
+                self?.tableView.reloadSections(IndexSet(integer: Section.sound.rawValue), with: .none)
+            }
+            if value == Int((MediaSettings.defaultVideoVolume * 100).rounded()) {
+                action.setValue(true, forKey: "checked")
+            }
+            alert.addAction(action)
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        if let popover = alert.popoverPresentationController {
+            popover.channerAnchor(in: self, sourceView: cell, sourceRect: cell.bounds, permittedArrowDirections: [.up, .down])
+        }
         present(alert, animated: true)
     }
 }

--- a/Channer/ViewControllers/Show Media/ImageGalleryVC.swift
+++ b/Channer/ViewControllers/Show Media/ImageGalleryVC.swift
@@ -551,6 +551,7 @@ class ImageGalleryVC: UIViewController, UICollectionViewDelegate, UICollectionVi
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellIdentifier, for: indexPath) as! MediaCell
         let imageURL = images[indexPath.row]
+        let fileExtension = imageURL.pathExtension.lowercased()
         
         print("📱 Configuring cell at index \(indexPath.row)")
         
@@ -558,7 +559,9 @@ class ImageGalleryVC: UIViewController, UICollectionViewDelegate, UICollectionVi
         cell.setSelected(indexPath.row == selectedIndex, animated: false)
         
         // Simplified approach: Treat all cells as potential videos in preload mode
-        if preloadVideos {
+        if fileExtension == "pdf" {
+            setupPDFCell(cell, url: imageURL)
+        } else if preloadVideos || (MediaSettings.replaceVideoThumbnails && (fileExtension == "webm" || fileExtension == "mp4")) {
             // Choose URL based on correctness map or fallback
             var videoURL = imageURL
             
@@ -645,6 +648,14 @@ class ImageGalleryVC: UIViewController, UICollectionViewDelegate, UICollectionVi
         cell.imageView?.kf.setImage(with: displayURL) { _ in
             cell.activityIndicator?.stopAnimating()
         }
+    }
+
+    private func setupPDFCell(_ cell: MediaCell, url: URL) {
+        let config = WKWebViewConfiguration()
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        cell.setupForVideo(configuration: config)
+        cell.webView?.navigationDelegate = self
+        cell.webView?.load(URLRequest(url: url))
     }
     
     /// Set up a cell to display a video - simpler, more reliable approach
@@ -1058,6 +1069,22 @@ class ImageGalleryVC: UIViewController, UICollectionViewDelegate, UICollectionVi
             urlWebVC.images = images
             urlWebVC.currentIndex = indexPath.row
             urlWebVC.enableSwipes = true
+            urlWebVC.refererString = refererString
+            urlWebVC.replyCount = postReplyCount
+            urlWebVC.onShowReplies = onShowRepliesForPost
+
+            if let navController = navigationController {
+                navController.pushViewController(urlWebVC, animated: true)
+            } else {
+                let navController = CatalystNavigationController(rootViewController: urlWebVC)
+                navController.modalPresentationStyle = .fullScreen
+                present(navController, animated: true)
+            }
+        } else if fileExtension == "pdf" {
+            let urlWebVC = urlWeb()
+            urlWebVC.images = [selectedURL]
+            urlWebVC.currentIndex = 0
+            urlWebVC.enableSwipes = false
             urlWebVC.refererString = refererString
             urlWebVC.replyCount = postReplyCount
             urlWebVC.onShowReplies = onShowRepliesForPost

--- a/Channer/ViewControllers/Show Media/WebMViewController.swift
+++ b/Channer/ViewControllers/Show Media/WebMViewController.swift
@@ -175,7 +175,7 @@ class WebMViewController: UIViewController, VLCMediaPlayerDelegate {
         player.allowsExternalPlayback = true
         let startMuted = MediaSettings.defaultMuted
         player.isMuted = startMuted
-        player.volume = startMuted ? 0.0 : 0.5
+        player.volume = startMuted ? 0.0 : MediaSettings.defaultVideoVolume
         return player
     }()
     /// AVPlayerLayer for rendering converted video
@@ -249,7 +249,7 @@ class WebMViewController: UIViewController, VLCMediaPlayerDelegate {
         player.drawable = videoView
         let startMuted = MediaSettings.defaultMuted
         player.audio?.isMuted = startMuted
-        player.audio?.volume = startMuted ? 0 : 50
+        player.audio?.volume = startMuted ? 0 : MediaSettings.defaultVLCVolume
         
         print("🎵 DEBUG: WebMViewController - VLC Player created")
         print("🎵 DEBUG: WebMViewController - Initial Audio Muted: \(player.audio?.isMuted ?? false)")
@@ -941,7 +941,7 @@ class WebMViewController: UIViewController, VLCMediaPlayerDelegate {
 
         // Apply mute settings
         avPlayer.isMuted = isMuted
-        avPlayer.volume = isMuted ? 0.0 : 0.5
+        avPlayer.volume = isMuted ? 0.0 : MediaSettings.defaultVideoVolume
 
         // Observe end of playback for looping
         avPlayerEndObserver = NotificationCenter.default.addObserver(
@@ -1205,7 +1205,7 @@ class WebMViewController: UIViewController, VLCMediaPlayerDelegate {
         }
 
         vlcPlayer.audio?.isMuted = false
-        vlcPlayer.audio?.volume = 50
+        vlcPlayer.audio?.volume = MediaSettings.defaultVLCVolume
     }
 
     private func logAudioDebug(_ context: String) {
@@ -1299,7 +1299,7 @@ class WebMViewController: UIViewController, VLCMediaPlayerDelegate {
 
         if isUsingAVPlayer {
             avPlayer.isMuted = isMuted
-            avPlayer.volume = isMuted ? 0.0 : 0.5
+            avPlayer.volume = isMuted ? 0.0 : MediaSettings.defaultVideoVolume
             updateOverlayMuteButton()
             print("🎵 DEBUG: WebMViewController - toggleMute() - Applied to AVPlayer, muted=\(avPlayer.isMuted)")
             return
@@ -1908,7 +1908,7 @@ class WebMViewController: UIViewController, VLCMediaPlayerDelegate {
         logAudioDebug("periodic-check")
         
         // Enforce user's mute preference
-        let expectedVolume = isMuted ? Int32(0) : Int32(50)
+        let expectedVolume = isMuted ? Int32(0) : MediaSettings.defaultVLCVolume
         if playerIsMuted != isMuted || playerVolume != expectedVolume {
             print("🎵 DEBUG: WebMViewController - Enforcing user mute preference...")
             if isMuted {

--- a/Channer/ViewControllers/Show Media/urlWeb.swift
+++ b/Channer/ViewControllers/Show Media/urlWeb.swift
@@ -313,7 +313,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
         player.allowsExternalPlayback = true
         let startMuted = MediaSettings.defaultMuted
         player.isMuted = startMuted
-        player.volume = startMuted ? 0.0 : 0.5
+        player.volume = startMuted ? 0.0 : MediaSettings.defaultVideoVolume
         return player
     }()
     
@@ -941,9 +941,9 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
     private func loadContentInternal() {
         isMuted = MediaSettings.defaultMuted
         avPlayer.isMuted = isMuted
-        avPlayer.volume = isMuted ? 0.0 : 0.5
+        avPlayer.volume = isMuted ? 0.0 : MediaSettings.defaultVideoVolume
         vlcPlayer?.audio?.isMuted = isMuted
-        vlcPlayer?.audio?.volume = isMuted ? Int32(0) : Int32(50)
+        vlcPlayer?.audio?.volume = isMuted ? Int32(0) : MediaSettings.defaultVLCVolume
         shouldForceMuteOnNextPlay = isMuted
         setupNavigationButtons()
 
@@ -1237,7 +1237,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
         vlcPlayer?.media = media
 
         vlcPlayer?.audio?.isMuted = isMuted
-        vlcPlayer?.audio?.volume = isMuted ? Int32(0) : Int32(50)
+        vlcPlayer?.audio?.volume = isMuted ? Int32(0) : MediaSettings.defaultVLCVolume
         
         // Start playback
         print("DEBUG: urlWeb - Starting VLC playback")
@@ -1268,7 +1268,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
             }
         } else {
             vlcPlayer.audio?.isMuted = false
-            vlcPlayer.audio?.volume = 50
+            vlcPlayer.audio?.volume = MediaSettings.defaultVLCVolume
             setupNavigationButtons()
         }
     }
@@ -1314,7 +1314,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
         print("🎵 DEBUG: urlWeb - Periodic check - Player Muted: \(playerIsMuted), Player Volume: \(playerVolume), User Preference: \(isMuted)")
         
         // Enforce user's mute preference
-        let expectedVolume = isMuted ? Int32(0) : Int32(50)
+        let expectedVolume = isMuted ? Int32(0) : MediaSettings.defaultVLCVolume
         if playerIsMuted != isMuted || playerVolume != expectedVolume {
             print("🎵 DEBUG: urlWeb - Enforcing user mute preference...")
             vlcPlayer.audio?.isMuted = isMuted
@@ -1451,7 +1451,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
             
             let defaultMuted = isMuted
             let mutedAttribute = defaultMuted ? "muted" : ""
-            let defaultVolume = defaultMuted ? "0" : "0.5"
+            let defaultVolume = defaultMuted ? "0" : "\(MediaSettings.defaultVideoVolume)"
 
             // Create custom HTML for video display with proper controls
             let videoHTML = """
@@ -1549,8 +1549,20 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
                     var sourceIndex = 0;
                     var sources = video.querySelectorAll('source');
                     const defaultMuted = \(defaultMuted ? "true" : "false");
-                    const defaultVolume = \(defaultMuted ? "0" : "0.5");
+                    const defaultVolume = \(defaultMuted ? "0" : "\(MediaSettings.defaultVideoVolume)");
+                    const wheelVolumeEnabled = \(MediaSettings.mouseWheelVolumeEnabled ? "true" : "false");
                     window._channerEnforceMuted = defaultMuted;
+
+                    if (wheelVolumeEnabled) {
+                        video.addEventListener('wheel', function(event) {
+                            if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey || video.muted) { return; }
+                            event.preventDefault();
+                            var volume = video.volume + 0.1;
+                            if (event.deltaY < 0) { volume *= 1.1; }
+                            if (event.deltaY > 0) { volume /= 1.1; }
+                            video.volume = Math.max(0, Math.min(1, volume - 0.1));
+                        }, { passive: false });
+                    }
                     
                     function shouldEnforceMute() {
                         return window._channerEnforceMuted === true;
@@ -1862,7 +1874,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
         // Apply mute state to VLC player if it's active
         if let vlcPlayer = vlcPlayer {
             vlcPlayer.audio?.isMuted = isMuted
-            vlcPlayer.audio?.volume = isMuted ? Int32(0) : Int32(50)
+            vlcPlayer.audio?.volume = isMuted ? Int32(0) : MediaSettings.defaultVLCVolume
             print("🎵 DEBUG: urlWeb - toggleMute() - Applied VLC settings")
             print("🎵 DEBUG: urlWeb - toggleMute() - VLC Audio Muted AFTER: \(vlcPlayer.audio?.isMuted ?? false)")
             print("🎵 DEBUG: urlWeb - toggleMute() - VLC Audio Volume AFTER: \(vlcPlayer.audio?.volume ?? -1)")
@@ -1870,7 +1882,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
         
         // Apply mute state to AVPlayer if it's active
         avPlayer.isMuted = isMuted
-        avPlayer.volume = isMuted ? 0.0 : 0.5
+        avPlayer.volume = isMuted ? 0.0 : MediaSettings.defaultVideoVolume
         print("🎵 DEBUG: urlWeb - toggleMute() - Applied AVPlayer settings")
         print("🎵 DEBUG: urlWeb - toggleMute() - AVPlayer Muted AFTER: \(avPlayer.isMuted)")
         print("🎵 DEBUG: urlWeb - toggleMute() - AVPlayer Volume AFTER: \(avPlayer.volume)")
@@ -1882,7 +1894,7 @@ class urlWeb: UIViewController, WKScriptMessageHandler, VLCMediaPlayerDelegate {
         if !webView.isHidden {
             let jsCommand = isMuted ?
                 "var video = document.getElementById('videoPlayer'); if (video) { video.muted = true; video.volume = 0; } window._channerEnforceMuted = true;" :
-                "var video = document.getElementById('videoPlayer'); if (video) { video.muted = false; video.volume = 0.5; } window._channerEnforceMuted = false;"
+                "var video = document.getElementById('videoPlayer'); if (video) { video.muted = false; video.volume = \(MediaSettings.defaultVideoVolume); } window._channerEnforceMuted = false;"
             webView.evaluateJavaScript(jsCommand) { result, error in
                 if let error = error {
                     print("DEBUG: urlWeb - Error updating web video mute state: \(error)")

--- a/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
+++ b/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
@@ -118,21 +118,7 @@ extension threadRepliesTV {
     ///   - useHQ: Whether to use high-quality thumbnails
     /// - Returns: Thumbnail URL or nil if conversion fails
     private func thumbnailURL(from raw: String, useHQ: Bool) -> URL? {
-        if raw.hasSuffix(".webm") || raw.hasSuffix(".mp4") {
-            let comps = raw.split(separator: "/")
-            if let last = comps.last {
-                let base = last.replacingOccurrences(of: ".webm", with: "").replacingOccurrences(of: ".mp4", with: "")
-                return URL(string: raw.replacingOccurrences(of: String(last), with: "\(base)s.jpg"))
-            }
-            return URL(string: raw)
-        }
-        if useHQ { return URL(string: raw) }
-        let comps = raw.split(separator: "/")
-        if let last = comps.last, let dot = last.firstIndex(of: ".") {
-            let filename = String(last[..<dot]) + "s.jpg"
-            return URL(string: raw.replacingOccurrences(of: String(last), with: filename))
-        }
-        return URL(string: raw)
+        return MediaSettings.thumbnailURL(from: raw, useHighQuality: useHQ)
     }
 }
 
@@ -224,7 +210,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     /// Open gallery view
     @objc func openGallery() {
         // Implementation depends on how your gallery view is shown
-        if totalImagesInThread > 0 {
+        if threadRepliesImages.contains(where: hasGalleryMedia) {
             showGallery()
         }
     }
@@ -1356,6 +1342,27 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
                 ThreadMoreOption(title: "Open in Browser", subtitle: "View this thread on the web", systemImageName: "safari") { [weak self] in
                     self?.openInBrowser()
                 }
+            ]),
+            ThreadMoreOptionsSection(title: "Media", options: [
+                ThreadMoreOption(title: MediaSettings.hidePostsWithoutImages ? "Show Text Posts" : "Hide Text Posts",
+                                 subtitle: "Toggle posts without attachments",
+                                 systemImageName: MediaSettings.hidePostsWithoutImages ? "text.bubble" : "photo.on.rectangle.angled") { [weak self] in
+                    MediaSettings.hidePostsWithoutImages.toggle()
+                    self?.hasPreloadedContent = false
+                    self?.debugReloadData(context: "Media visibility changed")
+                },
+                ThreadMoreOption(title: MediaSettings.hideAllImages ? "Show Images" : "Hide All Images",
+                                 subtitle: "Keep post text visible while hiding media thumbnails",
+                                 systemImageName: MediaSettings.hideAllImages ? "eye" : "eye.slash") { [weak self] in
+                    MediaSettings.hideAllImages.toggle()
+                    self?.hasPreloadedContent = false
+                    self?.debugReloadData(context: "Media visibility changed")
+                },
+                ThreadMoreOption(title: "Prefetch Media Now",
+                                 subtitle: "Warm image and video thumbnails for this thread",
+                                 systemImageName: "bolt") { [weak self] in
+                    self?.prefetchVisibleMediaNow()
+                }
             ])
         ]
 
@@ -1420,6 +1427,26 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         present(optionsController, animated: true)
     }
 
+    private func prefetchVisibleMediaNow() {
+        let useHQ = UserDefaults.standard.bool(forKey: "channer_high_quality_thumbnails_enabled")
+        let urls: [URL] = threadRepliesImages.enumerated().compactMap { index, raw in
+            guard isVisibleBySearchAndMediaSettings(index),
+                  raw != "https://i.4cdn.org/\(boardAbv)/" else { return nil }
+            let isSpoiler = index < postMetadataList.count && postMetadataList[index].isSpoiler
+            return MediaSettings.thumbnailURL(from: raw, useHighQuality: useHQ, isSpoiler: isSpoiler)
+        }
+
+        guard !urls.isEmpty else {
+            showAlert(title: "No Media", message: "No visible media is available to prefetch.")
+            return
+        }
+
+        imagePrefetcher?.stop()
+        imagePrefetcher = ImagePrefetcher(urls: urls)
+        imagePrefetcher?.start()
+        showAlert(title: "Prefetch Started", message: "\(urls.count) media thumbnail\(urls.count == 1 ? "" : "s") queued.")
+    }
+
     private func anchorMoreOptionsPopover(_ popover: UIPopoverPresentationController, sender: Any?) {
         if let barButtonItem = sender as? UIBarButtonItem {
             popover.channerAnchor(in: self, barButtonItem: barButtonItem, permittedArrowDirections: .up)
@@ -1467,7 +1494,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
 
         for (index, imageUrlString) in threadRepliesImages.enumerated() {
             guard let url = URL(string: imageUrlString) else { continue }
-            if url.absoluteString == "https://i.4cdn.org/\(boardAbv)/" { continue }
+            if url.absoluteString == "https://i.4cdn.org/\(boardAbv)/" || !MediaSettings.isSupportedGalleryURL(url) { continue }
 
             imageUrls.append(url)
 
@@ -1599,18 +1626,38 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
 
         let posterText = metadata?.posterId?.isEmpty == false ? metadata?.posterId ?? "" : "Unknown"
         let hashText = metadata?.fileHash?.isEmpty == false ? metadata?.fileHash ?? "" : "None"
-        let message = "Poster ID: \(posterText)\nFile: \(fileName)\nFile Hash: \(hashText)\nPosted: \(postedText)"
-        showAlert(title: "Post Info", message: message)
+        let spoilerText = metadata?.isSpoiler == true ? "\nSpoiler: Yes" : ""
+        let soundURL = MediaSettings.soundPostURL(from: metadata?.imageName)
+        let soundText = soundURL.map { "\nSound: \($0.absoluteString)" } ?? ""
+        let message = "Poster ID: \(posterText)\nFile: \(fileName)\nFile Hash: \(hashText)\nPosted: \(postedText)\(spoilerText)\(soundText)"
+
+        let alert = UIAlertController(title: "Post Info", message: message, preferredStyle: .alert)
+        if MediaSettings.webMMetadataEnabled,
+           metadata?.imageExtension?.lowercased() == ".webm",
+           let rawURL = metadata?.imageUrl,
+           let url = URL(string: rawURL) {
+            alert.addAction(UIAlertAction(title: "Fetch WebM Title", style: .default) { [weak self] _ in
+                WebMMetadataFetcher.shared.fetchTitle(for: url) { title in
+                    let titleText = title?.isEmpty == false ? title! : "No title metadata found."
+                    self?.showAlert(title: "WebM Metadata", message: titleText)
+                }
+            })
+        }
+        if let soundURL = soundURL {
+            alert.addAction(UIAlertAction(title: "Open Sound", style: .default) { _ in
+                UIApplication.shared.open(soundURL, options: [:], completionHandler: nil)
+            })
+        }
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
     
     // MARK: - Table View Data Source Methods
     /// Methods required to display data in the table view
     private func actualIndex(for indexPath: IndexPath) -> Int? {
-        guard isSearchActive && !searchText.isEmpty else { return indexPath.row }
-
         var visibleIndex = 0
         for dataIndex in 0..<threadReplies.count {
-            if !searchFilteredIndices.contains(dataIndex) {
+            if isVisibleBySearchAndMediaSettings(dataIndex) {
                 if visibleIndex == indexPath.row {
                     return dataIndex
                 }
@@ -1619,6 +1666,36 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         }
 
         return nil
+    }
+
+    private func isVisibleBySearchAndMediaSettings(_ index: Int) -> Bool {
+        if isSearchActive && !searchText.isEmpty && searchFilteredIndices.contains(index) {
+            return false
+        }
+        if MediaSettings.hidePostsWithoutImages && !postHasMedia(at: index) {
+            return false
+        }
+        return true
+    }
+
+    private func visiblePostCount() -> Int {
+        var count = 0
+        for index in 0..<threadReplies.count where isVisibleBySearchAndMediaSettings(index) {
+            count += 1
+        }
+        return count
+    }
+
+    private func postHasMedia(at index: Int) -> Bool {
+        guard index < threadRepliesImages.count else { return false }
+        let raw = threadRepliesImages[index]
+        return !raw.isEmpty && raw != "https://i.4cdn.org/\(boardAbv)/"
+    }
+
+    private func hasGalleryMedia(_ raw: String) -> Bool {
+        guard let url = URL(string: raw),
+              raw != "https://i.4cdn.org/\(boardAbv)/" else { return false }
+        return MediaSettings.isSupportedGalleryURL(url)
     }
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
@@ -1630,12 +1707,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             return 0
         }
         
-        // If search is active, only count unfiltered rows
-        if isSearchActive && !searchText.isEmpty {
-            return threadReplies.count - searchFilteredIndices.count
-        }
-        
-        return threadReplies.count
+        return visiblePostCount()
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -1689,7 +1761,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
                            replyCount: 0)
         } else {
             let imageUrl = threadRepliesImages[actualIndex]
-            let hasImage = imageUrl != "https://i.4cdn.org/\(boardAbv)/"
+            let hasImage = imageUrl != "https://i.4cdn.org/\(boardAbv)/" && !MediaSettings.hideAllImages
             let attributedText = threadReplies[actualIndex]
             let boardNumber = threadBoardReplyNumber[actualIndex]
             let isFiltered = filteredReplyIndices.contains(actualIndex)
@@ -1723,7 +1795,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             // Set up image if present
             if hasImage {
                 print("🔄 CELL: Cell \(indexPath.row) has image, calling configureImage")
-                configureImage(for: cell, with: imageUrl, at: indexPath)
+                configureImage(for: cell, with: imageUrl, at: indexPath, postIndex: actualIndex)
                 
                 // Prepare cell for hover interaction
                 if #available(iOS 13.4, *) {
@@ -1731,7 +1803,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
                     cell.threadImage.layer.borderWidth = 0.0
                     
                     // Store the image URL for hover preview
-                    cell.setImageURL(imageUrl) 
+                    cell.setImageURL(imageUrl)
                 }
                 cell.threadImage.tag = actualIndex
                 cell.threadImage.addTarget(self, action: #selector(threadContentOpen), for: .touchUpInside)
@@ -1810,11 +1882,13 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             return
         }
         let urls: [URL] = indexPaths.compactMap { ip in
-            guard ip.row < threadRepliesImages.count else { return nil }
-            let raw = threadRepliesImages[ip.row]
+            guard let actualIndex = actualIndex(for: ip),
+                  actualIndex < threadRepliesImages.count else { return nil }
+            let raw = threadRepliesImages[actualIndex]
             guard !raw.isEmpty, raw != "https://i.4cdn.org/\(boardAbv)/" else { return nil }
             let useHQ = UserDefaults.standard.bool(forKey: "channer_high_quality_thumbnails_enabled")
-            return thumbnailURL(from: raw, useHQ: useHQ)
+            let isSpoiler = actualIndex < postMetadataList.count && postMetadataList[actualIndex].isSpoiler
+            return MediaSettings.thumbnailURL(from: raw, useHighQuality: useHQ, isSpoiler: isSpoiler)
         }
         guard !urls.isEmpty else { return }
         imagePrefetcher?.stop()
@@ -2303,6 +2377,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         let countryName = post["country_name"].stringValue  // Country name
         let timestamp = post["time"].int  // Unix timestamp
         let fileHash = post["md5"].stringValue  // File hash (if available)
+        let isSpoiler = post["spoiler"].boolValue
 
         // Create PostMetadata for advanced filtering
         let metadata = PostMetadata(
@@ -2316,7 +2391,8 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             imageUrl: imageURL.isEmpty ? nil : imageURL,
             imageExtension: imageExtension.isEmpty ? nil : imageExtension,
             imageName: imageName.isEmpty ? nil : imageName,
-            fileHash: fileHash.isEmpty ? nil : fileHash
+            fileHash: fileHash.isEmpty ? nil : fileHash,
+            isSpoiler: isSpoiler
         )
         postMetadataList.append(metadata)
     }
@@ -2677,11 +2753,13 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     
     // MARK: - Image Handling Methods
     /// Methods to handle image loading and interactions
-    private func configureImage(for cell: threadRepliesCell, with imageUrl: String, at indexPath: IndexPath? = nil) {
+    private func configureImage(for cell: threadRepliesCell, with imageUrl: String, at indexPath: IndexPath? = nil, postIndex: Int? = nil) {
         print("Debug: Starting image configuration for URL: \(imageUrl)")
 
         let useHighQualityThumbnails = UserDefaults.standard.bool(forKey: "channer_high_quality_thumbnails_enabled")
-        let thumbnailUrl = thumbnailURL(from: imageUrl, useHQ: useHighQualityThumbnails)
+        let resolvedPostIndex = postIndex ?? indexPath.flatMap { actualIndex(for: $0) }
+        let isSpoiler = resolvedPostIndex.flatMap { $0 < postMetadataList.count ? postMetadataList[$0].isSpoiler : nil } ?? false
+        let thumbnailUrl = MediaSettings.thumbnailURL(from: imageUrl, useHighQuality: useHighQualityThumbnails, isSpoiler: isSpoiler)
 
         if let thumbnailUrl, cell.displayedThumbnailURL == thumbnailUrl, cell.threadImage.thumbnailImageView.image != nil {
             cell.setImageURL(imageUrl)
@@ -2711,65 +2789,8 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             return
         }
         
-        // Extract file extension from URL
-        let fileExtension: String
-        if imageUrl.hasSuffix(".jpg") {
-            fileExtension = ".jpg"
-        } else if imageUrl.hasSuffix(".png") {
-            fileExtension = ".png"
-            print("Debug: PNG image detected in configureImage: \(imageUrl)")
-        } else if imageUrl.hasSuffix(".webm") {
-            fileExtension = ".webm"
-        } else if imageUrl.hasSuffix(".mp4") {
-            fileExtension = ".mp4"
-        } else {
-            // Default to JPG if extension can't be determined
-            fileExtension = ".jpg"
-            print("Debug: Unknown extension, defaulting to JPG for: \(imageUrl)")
-        }
-        
-        let finalUrl: String
-        if fileExtension == ".webm" || fileExtension == ".mp4" {
-            let components = imageUrl.components(separatedBy: "/")
-            if let last = components.last {
-                let base = last.replacingOccurrences(of: fileExtension, with: "")
-                
-                // For videos, always use thumbnail ("s.jpg" suffix)
-                finalUrl = imageUrl.replacingOccurrences(of: last, with: "\(base)s.jpg")
-                print("Debug: Video thumbnail URL: \(finalUrl)")
-            } else {
-                finalUrl = imageUrl
-            }
-        } else {
-            // For images, use full image URL or thumbnail URL based on user preference
-            if useHighQualityThumbnails {
-                // Use the original full-quality image URL
-                finalUrl = imageUrl
-                print("Debug: Using high-quality image: \(finalUrl)")
-            } else {
-                // Use the thumbnail URL by adding "s" before the extension
-                let components = imageUrl.components(separatedBy: "/")
-                if let last = components.last, let range = last.range(of: ".") {
-                    let filename = String(last[..<range.lowerBound])
-                    
-                    // 4chan always uses JPG for thumbnails regardless of the original file type
-                    let thumbnailFilename = filename + "s.jpg"
-                    finalUrl = imageUrl.replacingOccurrences(of: last, with: thumbnailFilename)
-                    
-                    if fileExtension == ".png" {
-                        print("Debug: Using JPG thumbnail for PNG image: \(finalUrl)")
-                    } else {
-                        print("Debug: Generated thumbnail URL: \(finalUrl) for image type: \(fileExtension)")
-                    }
-                } else {
-                    finalUrl = imageUrl
-                    print("Debug: Could not parse URL components, using original: \(finalUrl)")
-                }
-            }
-        }
-        
-        guard let url = URL(string: finalUrl) else {
-            print("Debug: Invalid URL: \(finalUrl)")
+        guard let url = thumbnailUrl else {
+            print("Debug: Invalid URL: \(imageUrl)")
             cell.threadImage.thumbnailImageView.image = UIImage(named: "loadingBoardImage")
             return
         }
@@ -2791,6 +2812,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         ]
         
         print("Debug: Loading image with URL: \(url)")
+        let finalUrl = url.absoluteString
 
         let placeholderImage: UIImage?
         if cell.displayedThumbnailURL == url {
@@ -4806,11 +4828,12 @@ extension threadRepliesTV {
     }
     
     private func configureCellImage(cell: threadRepliesCell, at indexPath: IndexPath) {
-        guard indexPath.row < threadRepliesImages.count else { return }
+        guard let actualIndex = actualIndex(for: indexPath),
+              actualIndex < threadRepliesImages.count else { return }
         
-        let imageURL = threadRepliesImages[indexPath.row]
+        let imageURL = threadRepliesImages[actualIndex]
         if !imageURL.isEmpty && imageURL != "https://i.4cdn.org/\(boardAbv)/" {
-            configureImage(for: cell, with: imageURL)
+            configureImage(for: cell, with: imageURL, at: indexPath, postIndex: actualIndex)
         }
     }
     
@@ -4823,7 +4846,7 @@ extension threadRepliesTV {
         let useHighQualityThumbnails = UserDefaults.standard.bool(forKey: "channer_high_quality_thumbnails_enabled")
         
         // Generate thumbnail URL using same method as normal loading
-        let thumbnailUrl = thumbnailURL(from: imageUrl, useHQ: useHighQualityThumbnails)
+        let thumbnailUrl = MediaSettings.thumbnailURL(from: imageUrl, useHighQuality: useHighQualityThumbnails)
         print("🚀 LOAD: Thumbnail URL: \(thumbnailUrl?.absoluteString ?? "nil")")
         
         guard let url = thumbnailUrl else {

--- a/Channer/iPad/threadRepliesCV.swift
+++ b/Channer/iPad/threadRepliesCV.swift
@@ -108,6 +108,18 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
 
         let fileHash = dict["md5"] as? String
         threadRepliesFileHashes.append(fileHash)
+
+        let spoiler: Bool
+        if let boolValue = dict["spoiler"] as? Bool {
+            spoiler = boolValue
+        } else if let intValue = dict["spoiler"] as? Int {
+            spoiler = intValue != 0
+        } else if let numberValue = dict["spoiler"] as? NSNumber {
+            spoiler = numberValue.boolValue
+        } else {
+            spoiler = false
+        }
+        threadRepliesSpoilers.append(spoiler)
     }
     
     // MARK: - Properties
@@ -136,6 +148,8 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
     var threadRepliesPosterIds: [String?] = []
     /// Array of thread reply file hashes
     var threadRepliesFileHashes: [String?] = []
+    /// Array of spoiler flags for media attachments
+    var threadRepliesSpoilers: [Bool] = []
     /// Backup array of old thread replies
     var threadRepliesOld: [String] = []
     /// Array of thread board reply numbers
@@ -273,6 +287,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
             threadRepliesTimestamps = []
             threadRepliesPosterIds = []
             threadRepliesFileHashes = []
+            threadRepliesSpoilers = []
 
             for dict in posts {
                 
@@ -313,6 +328,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
             threadRepliesTimestamps = []
             threadRepliesPosterIds = []
             threadRepliesFileHashes = []
+            threadRepliesSpoilers = []
             
             for dict in posts {
                 
@@ -478,9 +494,27 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
     override func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }
+
+    private func visibleReplyIndices() -> [Int] {
+        guard MediaSettings.hidePostsWithoutImages else {
+            return Array(threadReplies.indices)
+        }
+
+        return threadReplies.indices.filter { index in
+            guard index < threadRepliesImages.count else { return false }
+            let raw = threadRepliesImages[index]
+            return !raw.isEmpty && raw != "https://i.4cdn.org/\(boardAbv)/"
+        }
+    }
+
+    private func dataIndex(for visibleIndex: Int) -> Int? {
+        let indices = visibleReplyIndices()
+        guard visibleIndex >= 0 && visibleIndex < indices.count else { return nil }
+        return indices[visibleIndex]
+    }
     
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return threadReplies.count
+        return visibleReplyIndices().count
     }
     
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -490,8 +524,8 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
         // Set up hover features for Apple Pencil
         if #available(iOS 13.4, *) {
             // Configure hover for thread image button if we have an image URL
-            if indexPath.row < threadRepliesImages.count {
-                let imageUrl = threadRepliesImages[indexPath.row]
+            if let dataIndex = dataIndex(for: indexPath.row), dataIndex < threadRepliesImages.count {
+                let imageUrl = threadRepliesImages[dataIndex]
                 let hasImage = imageUrl != "https://i.4cdn.org/\(boardAbv)/"
                 
                 if hasImage && cell.threadImage != nil {
@@ -516,11 +550,12 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
     }
 
     override func collectionView(_ collectionView: UICollectionView, leadingSwipeActionsConfigurationForItemAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard indexPath.row < threadBoardReplyNumber.count else {
+        guard let dataIndex = dataIndex(for: indexPath.row),
+              dataIndex < threadBoardReplyNumber.count else {
             return nil
         }
 
-        let postNo = threadBoardReplyNumber[indexPath.row]
+        let postNo = threadBoardReplyNumber[dataIndex]
         var actions: [UIContextualAction] = []
 
         if let postNoInt = Int(postNo) {
@@ -534,7 +569,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
         }
 
         let infoAction = UIContextualAction(style: .normal, title: "Info") { [weak self] _, _, completion in
-            self?.showPostInfo(for: indexPath.row)
+            self?.showPostInfo(for: dataIndex)
             completion(true)
         }
         infoAction.backgroundColor = .systemGray
@@ -543,7 +578,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
 
         if let replies = threadBoardReplies[postNo], !replies.isEmpty {
             let repliesAction = UIContextualAction(style: .normal, title: "Replies") { [weak self] _, _, completion in
-                self?.showThreadForIndex(indexPath.row)
+                self?.showThreadForIndex(dataIndex)
                 completion(true)
             }
             repliesAction.backgroundColor = .systemTeal
@@ -587,8 +622,29 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
 
         let posterText = index < threadRepliesPosterIds.count ? (threadRepliesPosterIds[index] ?? "Unknown") : "Unknown"
         let hashText = index < threadRepliesFileHashes.count ? (threadRepliesFileHashes[index] ?? "None") : "None"
-        let message = "Poster ID: \(posterText)\nFile: \(fileName)\nFile Hash: \(hashText)\nPosted: \(postedText)"
+        let spoilerText = (index < threadRepliesSpoilers.count && threadRepliesSpoilers[index]) ? "\nSpoiler: Yes" : ""
+        let soundURL = MediaSettings.soundPostURL(from: index < threadRepliesFileNames.count ? threadRepliesFileNames[index] : nil)
+        let soundText = soundURL.map { "\nSound: \($0.absoluteString)" } ?? ""
+        let message = "Poster ID: \(posterText)\nFile: \(fileName)\nFile Hash: \(hashText)\nPosted: \(postedText)\(spoilerText)\(soundText)"
         let alert = UIAlertController(title: "Post Info", message: message, preferredStyle: .alert)
+        if MediaSettings.webMMetadataEnabled,
+           index < threadRepliesImages.count,
+           let url = URL(string: threadRepliesImages[index]),
+           url.pathExtension.lowercased() == "webm" {
+            alert.addAction(UIAlertAction(title: "Fetch WebM Title", style: .default) { [weak self] _ in
+                WebMMetadataFetcher.shared.fetchTitle(for: url) { title in
+                    let titleText = title?.isEmpty == false ? title! : "No title metadata found."
+                    let titleAlert = UIAlertController(title: "WebM Metadata", message: titleText, preferredStyle: .alert)
+                    titleAlert.addAction(UIAlertAction(title: "OK", style: .default))
+                    self?.present(titleAlert, animated: true)
+                }
+            })
+        }
+        if let soundURL = soundURL {
+            alert.addAction(UIAlertAction(title: "Open Sound", style: .default) { _ in
+                UIApplication.shared.open(soundURL, options: [:], completionHandler: nil)
+            })
+        }
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         present(alert, animated: true)
     }
@@ -673,11 +729,13 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
         // Reply button hidden - feature moved to long press menu
         cell.thread.isHidden = true
 
-        // Show subject for first cell (OP)
-        cell.configureSubject(indexPath.row == 0 ? threadSubject : nil)
-
         // Set post number
-        let boardNumber = threadBoardReplyNumber[indexPath.row]
+        guard let dataIndex = dataIndex(for: indexPath.row) else { return }
+
+        // Show subject for first cell (OP)
+        cell.configureSubject(dataIndex == 0 ? threadSubject : nil)
+
+        let boardNumber = threadBoardReplyNumber[dataIndex]
         cell.boardReplyCount.text = boardNumber
 
         // Set reply count (number of replies to this post)
@@ -690,63 +748,37 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
         }
 
         // Configure content
-        let imageUrl = threadRepliesImages[indexPath.row]
-        if imageUrl.contains("nullnull") {
-            configureTextOnlyCell(cell, at: indexPath)
+        let imageUrl = threadRepliesImages[dataIndex]
+        if imageUrl.contains("nullnull") || imageUrl == "https://i.4cdn.org/\(boardAbv)/" || MediaSettings.hideAllImages {
+            configureTextOnlyCell(cell, dataIndex: dataIndex)
         } else {
-            configureMediaCell(cell, at: indexPath, imageUrl: imageUrl)
+            configureMediaCell(cell, at: indexPath, dataIndex: dataIndex, imageUrl: imageUrl)
         }
     }
     
-    private func configureTextOnlyCell(_ cell: threadReplyCell, at indexPath: IndexPath) {
+    private func configureTextOnlyCell(_ cell: threadReplyCell, dataIndex: Int) {
         cell.replyTextNoImage.isHidden = false
         cell.replyText.isHidden = true
         cell.threadImage.isHidden = true
-        cell.replyTextNoImage.text = threadReplies[indexPath.row].replacingOccurrences(of: "null", with: "")
+        cell.replyTextNoImage.text = threadReplies[dataIndex].replacingOccurrences(of: "null", with: "")
     }
     
-    private func configureMediaCell(_ cell: threadReplyCell, at indexPath: IndexPath, imageUrl: String) {
+    private func configureMediaCell(_ cell: threadReplyCell, at indexPath: IndexPath, dataIndex: Int, imageUrl: String) {
         
         cell.replyTextNoImage.isHidden = true
         cell.replyText.isHidden = false
         cell.threadImage.isHidden = false
-        cell.replyText.text = threadReplies[indexPath.row].replacingOccurrences(of: "null", with: "")
+        cell.replyText.text = threadReplies[dataIndex].replacingOccurrences(of: "null", with: "")
         
         print("Debug (iPad): Configuring media cell with image URL: \(imageUrl)")
-                
-        let finalImageUrl: String
-        if imageUrl.contains(".webm") {
-            finalImageUrl = imageUrl.replacingOccurrences(of: ".webm", with: "s.jpg")
-            print("Debug (iPad): Using JPG thumbnail for WebM: \(finalImageUrl)")
-        } else if imageUrl.contains(".mp4") {
-            finalImageUrl = imageUrl.replacingOccurrences(of: ".mp4", with: "s.jpg")
-            print("Debug (iPad): Using JPG thumbnail for MP4: \(finalImageUrl)")
-        } else if imageUrl.contains(".png") {
-            // Get thumbnail URL for PNG image - 4chan uses JPG thumbnails even for PNG files
-            let components = imageUrl.components(separatedBy: "/")
-            if let last = components.last, let range = last.range(of: ".") {
-                let filename = String(last[..<range.lowerBound])
-                // Always use .jpg extension for thumbnails, even for PNG files
-                let thumbnailFilename = filename + "s.jpg"
-                finalImageUrl = imageUrl.replacingOccurrences(of: last, with: thumbnailFilename)
-                print("Debug (iPad): Using JPG thumbnail for PNG: \(finalImageUrl)")
-            } else {
-                finalImageUrl = imageUrl
-                print("Debug (iPad): Using original PNG URL: \(finalImageUrl)")
-            }
-        } else {
-            // Default JPG handling
-            let components = imageUrl.components(separatedBy: "/")
-            if let last = components.last, let range = last.range(of: ".") {
-                let filename = String(last[..<range.lowerBound])
-                let thumbnailFilename = filename + "s.jpg"
-                finalImageUrl = imageUrl.replacingOccurrences(of: last, with: thumbnailFilename)
-                print("Debug (iPad): Using JPG thumbnail: \(finalImageUrl)")
-            } else {
-                finalImageUrl = imageUrl
-                print("Debug (iPad): Using original URL: \(finalImageUrl)")
-            }
+
+        let isSpoiler = dataIndex < threadRepliesSpoilers.count && threadRepliesSpoilers[dataIndex]
+        let useHQ = UserDefaults.standard.bool(forKey: "channer_high_quality_thumbnails_enabled")
+        guard let thumbnailURL = MediaSettings.thumbnailURL(from: imageUrl, useHighQuality: useHQ, isSpoiler: isSpoiler) else {
+            cell.threadImage.setImage(UIImage(named: "loadingBoardImage"), for: .normal)
+            return
         }
+        let finalImageUrl = thumbnailURL.absoluteString
                 
         // Correct way to set image on UIButton using Kingfisher
         if let url = URL(string: finalImageUrl) {
@@ -783,7 +815,7 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
                 }
         }
                 
-        cell.threadImage.tag = indexPath.row
+        cell.threadImage.tag = dataIndex
         cell.threadImage.layer.cornerRadius = 12
         cell.threadImage.contentMode = .scaleAspectFill
         cell.threadImage.addTarget(self, action: #selector(threadContentOpen), for: .touchUpInside)
@@ -822,9 +854,14 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
         var imageURLs: [URL] = []
         var galleryPostNumbers: [String] = []
         var galleryReplyCounts: [Int] = []
+        var selectedGalleryIndex: Int?
 
         for (index, urlString) in processedImageLinks.enumerated() {
             guard let url = URL(string: urlString) else { continue }
+            if url.absoluteString == "https://i.4cdn.org/\(boardAbv)/" || !MediaSettings.isSupportedGalleryURL(url) { continue }
+            if index == selectedIndex {
+                selectedGalleryIndex = imageURLs.count
+            }
             imageURLs.append(url)
             if index < threadBoardReplyNumber.count {
                 let postNo = threadBoardReplyNumber[index]
@@ -844,8 +881,8 @@ class threadRepliesCV: UICollectionViewController, QuoteLinkHoverDelegate {
                 self?.showThreadForPostNumber(postNumber)
             }
         }
-        if selectedIndex < imageURLs.count {
-            galleryVC.selectedImageURL = imageURLs[selectedIndex]
+        if let selectedGalleryIndex = selectedGalleryIndex, selectedGalleryIndex < imageURLs.count {
+            galleryVC.selectedImageURL = imageURLs[selectedGalleryIndex]
         }
 
         print("Debug (iPad): Presenting image gallery with \(imageURLs.count) images")


### PR DESCRIPTION
## Summary
- Expand media settings to cover XT-style controls for spoiler reveal, thumbnail replacement, hide text/image posts, prefetch behavior, sound posts, mouse-wheel volume, WebM metadata, and PDF gallery support.
- Update thread reply views on iPhone and iPad to respect the new visibility and thumbnail rules, including gallery filtering and post info actions.
- Add WebM title metadata fetching, default volume handling, wheel-volume support for web video playback, and PDF rendering in the media gallery.

## Testing
- Built the app locally with `./build.sh`.
- Performed targeted simulator validation for the updated media-related flows and gallery behavior.