### PR TITLE
Add XT-style filter parity to Channer

### DIFF
--- a/Channer/Utilities/AdvancedFilter.swift
+++ b/Channer/Utilities/AdvancedFilter.swift
@@ -4,6 +4,7 @@ import Foundation
 
 /// Represents the different types of advanced filters available
 enum FilterType: String, Codable, CaseIterable {
+    case xtGeneral = "xt_general"
     case keyword = "keyword"
     case regex = "regex"
     case posterId = "poster_id"
@@ -12,9 +13,17 @@ enum FilterType: String, Codable, CaseIterable {
     case countryFlag = "country_flag"
     case tripCode = "trip_code"
     case timeBased = "time_based"
+    case subject = "subject"
+    case email = "email"
+    case capcode = "capcode"
+    case passDate = "pass"
+    case dimensions = "dimensions"
+    case fileSize = "filesize"
+    case md5 = "md5"
 
     var displayName: String {
         switch self {
+        case .xtGeneral: return "XT General"
         case .keyword: return "Keyword"
         case .regex: return "Regex Pattern"
         case .posterId: return "Poster ID"
@@ -23,11 +32,19 @@ enum FilterType: String, Codable, CaseIterable {
         case .countryFlag: return "Country Flag"
         case .tripCode: return "Trip Code"
         case .timeBased: return "Time-Based"
+        case .subject: return "Subject"
+        case .email: return "Email"
+        case .capcode: return "Capcode"
+        case .passDate: return "Pass Date"
+        case .dimensions: return "Image Dimensions"
+        case .fileSize: return "Filesize"
+        case .md5: return "Image MD5"
         }
     }
 
     var description: String {
         switch self {
+        case .xtGeneral: return "Filter posts using XT's multi-field filter syntax"
         case .keyword: return "Filter posts containing specific text"
         case .regex: return "Filter posts matching a regex pattern"
         case .posterId: return "Filter posts from specific poster IDs"
@@ -36,6 +53,116 @@ enum FilterType: String, Codable, CaseIterable {
         case .countryFlag: return "Filter posts by country flag"
         case .tripCode: return "Filter posts by trip code"
         case .timeBased: return "Filter posts older than specified time"
+        case .subject: return "Filter posts by subject"
+        case .email: return "Filter posts by email/options"
+        case .capcode: return "Filter posts by capcode"
+        case .passDate: return "Filter posts by 4chan Pass date"
+        case .dimensions: return "Filter posts by image dimensions"
+        case .fileSize: return "Filter posts by filesize"
+        case .md5: return "Filter posts by image MD5"
+        }
+    }
+}
+
+// MARK: - XT Filter Language
+
+enum XTFilterField: String, Codable, CaseIterable {
+    case postID
+    case name
+    case uniqueID
+    case tripcode
+    case capcode
+    case pass
+    case email
+    case subject
+    case comment
+    case flag
+    case filename
+    case dimensions
+    case filesize
+    case MD5
+}
+
+enum XTPostScope: String, Codable {
+    case any
+    case repliesOnly
+    case opOnly
+}
+
+enum XTFileScope: String, Codable {
+    case any
+    case withFileOnly
+    case withoutFileOnly
+}
+
+struct XTFilterOptions: Codable, Equatable {
+    var boards: [String]?
+    var excludedBoards: [String]?
+    var postScope: XTPostScope
+    var fileScope: XTFileScope
+    var stub: Bool?
+    var highlightClass: String?
+    var pinToTop: Bool?
+    var notify: Bool
+    var samePoster: Bool
+    var recursiveReplies: Bool
+    var hide: Bool
+    var reason: String?
+    var generalFieldGroups: [[XTFilterField]]?
+
+    init(
+        boards: [String]? = nil,
+        excludedBoards: [String]? = nil,
+        postScope: XTPostScope = .any,
+        fileScope: XTFileScope = .any,
+        stub: Bool? = nil,
+        highlightClass: String? = nil,
+        pinToTop: Bool? = nil,
+        notify: Bool = false,
+        samePoster: Bool = false,
+        recursiveReplies: Bool = false,
+        hide: Bool = true,
+        reason: String? = nil,
+        generalFieldGroups: [[XTFilterField]]? = nil
+    ) {
+        self.boards = boards
+        self.excludedBoards = excludedBoards
+        self.postScope = postScope
+        self.fileScope = fileScope
+        self.stub = stub
+        self.highlightClass = highlightClass
+        self.pinToTop = pinToTop
+        self.notify = notify
+        self.samePoster = samePoster
+        self.recursiveReplies = recursiveReplies
+        self.hide = hide
+        self.reason = reason
+        self.generalFieldGroups = generalFieldGroups
+    }
+}
+
+struct AdvancedFilterEffect: Equatable {
+    let filterID: UUID
+    let shouldHide: Bool
+    let showStub: Bool?
+    let reason: String?
+    let highlightClass: String?
+    let pinToTop: Bool
+    let notify: Bool
+    let samePoster: Bool
+    let recursiveReplies: Bool
+}
+
+enum XTFilterParseError: Error, LocalizedError {
+    case missingPattern
+    case unknownField(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingPattern:
+            return "XT filters must start with a /pattern/ expression."
+        case .unknownField(let field):
+            return "Unknown XT filter field: \(field)"
         }
     }
 }
@@ -126,6 +253,10 @@ struct AdvancedFilter: Codable, Equatable, Identifiable {
     var timeValue: Int?
     var timeUnit: TimeUnit?
 
+    // XT filter language specific
+    var xtOptions: XTFilterOptions?
+    var xtRegexFlags: String?
+
     // Metadata
     var createdAt: Date
     var modifiedAt: Date
@@ -139,7 +270,9 @@ struct AdvancedFilter: Codable, Equatable, Identifiable {
         filterMode: FilterMode = .blacklist,
         fileTypeFilter: FileTypeFilter? = nil,
         timeValue: Int? = nil,
-        timeUnit: TimeUnit? = nil
+        timeUnit: TimeUnit? = nil,
+        xtOptions: XTFilterOptions? = nil,
+        xtRegexFlags: String? = nil
     ) {
         self.id = UUID()
         self.filterType = filterType
@@ -150,6 +283,8 @@ struct AdvancedFilter: Codable, Equatable, Identifiable {
         self.fileTypeFilter = fileTypeFilter
         self.timeValue = timeValue
         self.timeUnit = timeUnit
+        self.xtOptions = xtOptions
+        self.xtRegexFlags = xtRegexFlags
         self.createdAt = Date()
         self.modifiedAt = Date()
         self.hitCount = 0
@@ -204,10 +339,28 @@ struct AdvancedFilter: Codable, Equatable, Identifiable {
         )
     }
 
+    /// Creates an exact MD5 filter, matching XT's MD5 filter behavior.
+    static func md5(_ hash: String) -> AdvancedFilter {
+        return AdvancedFilter(filterType: .md5, value: hash)
+    }
+
+    /// Creates a filter from an XT line such as "/pattern/i;boards:g;op:only;reason:Bait".
+    static func xt(_ line: String, type: FilterType = .xtGeneral) throws -> AdvancedFilter {
+        let parsed = try XTFilterLineParser.parse(line, defaultType: type)
+        return AdvancedFilter(
+            filterType: parsed.type,
+            value: parsed.pattern,
+            isCaseSensitive: !parsed.flags.contains("i"),
+            filterMode: .blacklist,
+            xtOptions: parsed.options,
+            xtRegexFlags: parsed.flags
+        )
+    }
+
     /// Display name for the filter
     var displayName: String {
         switch filterType {
-        case .keyword, .regex, .posterId, .imageName:
+        case .keyword, .regex, .posterId, .imageName, .xtGeneral, .subject, .email, .capcode, .passDate, .dimensions, .fileSize, .md5:
             return value
         case .fileType:
             return fileTypeFilter?.displayName ?? value
@@ -230,15 +383,26 @@ struct AdvancedFilter: Codable, Equatable, Identifiable {
 struct PostMetadata: Codable {
     let postNumber: String
     let comment: String
-    let posterId: String?
-    let tripCode: String?
-    let countryCode: String?
-    let countryName: String?
-    let timestamp: Int?  // Unix timestamp
-    let imageUrl: String?
-    let imageExtension: String?
-    let imageName: String?
-    let fileHash: String?
+    var posterId: String? = nil
+    var tripCode: String? = nil
+    var countryCode: String? = nil
+    var countryName: String? = nil
+    var timestamp: Int? = nil  // Unix timestamp
+    var imageUrl: String? = nil
+    var imageExtension: String? = nil
+    var imageName: String? = nil
+    var fileHash: String? = nil
+    var boardAbv: String? = nil
+    var threadNumber: String? = nil
+    var subject: String? = nil
+    var name: String? = nil
+    var email: String? = nil
+    var capcode: String? = nil
+    var passDate: String? = nil
+    var imageDimensions: String? = nil
+    var imageFileSize: String? = nil
+    var isOP: Bool = false
+    var isTopThread: Bool = false
 
     /// Checks if post has an attachment
     var hasAttachment: Bool {
@@ -268,6 +432,16 @@ struct PostMetadata: Codable {
         guard let ts = timestamp else { return nil }
         return Date().timeIntervalSince1970 - TimeInterval(ts)
     }
+
+    var quotedPostNumbers: [String] {
+        let pattern = ">>([0-9]+)"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return [] }
+        let nsRange = NSRange(comment.startIndex..<comment.endIndex, in: comment)
+        return regex.matches(in: comment, options: [], range: nsRange).compactMap { match in
+            guard let range = Range(match.range(at: 1), in: comment) else { return nil }
+            return String(comment[range])
+        }
+    }
 }
 
 // MARK: - Filter Matching Logic
@@ -278,9 +452,32 @@ extension AdvancedFilter {
     /// - Parameter post: The post metadata to check
     /// - Returns: True if the post should be hidden (for blacklist) or shown (for whitelist)
     func matches(post: PostMetadata) -> Bool {
-        guard isEnabled else { return false }
+        guard isEnabled, appliesToPostContext(post) else { return false }
+        return rawMatches(post: post)
+    }
 
+    func matchEffect(post: PostMetadata, defaultShowStub: Bool) -> AdvancedFilterEffect? {
+        guard matches(post: post) else { return nil }
+        let options = xtOptions
+        let shouldHide = options?.hide ?? (filterMode == .blacklist)
+        return AdvancedFilterEffect(
+            filterID: id,
+            shouldHide: shouldHide,
+            showStub: options?.stub ?? defaultShowStub,
+            reason: options?.reason ?? defaultReason,
+            highlightClass: options?.highlightClass,
+            pinToTop: options?.pinToTop ?? false,
+            notify: options?.notify ?? false,
+            samePoster: options?.samePoster ?? false,
+            recursiveReplies: options?.recursiveReplies ?? false
+        )
+    }
+
+    private func rawMatches(post: PostMetadata) -> Bool {
         switch filterType {
+        case .xtGeneral:
+            return matchesXTGeneral(post)
+
         case .keyword:
             return matchesKeyword(post.comment)
 
@@ -308,6 +505,41 @@ extension AdvancedFilter {
 
         case .timeBased:
             return matchesTimeBased(post)
+
+        case .subject:
+            return post.subject.map { matchesRegexOrContains($0) } ?? false
+
+        case .email:
+            return post.email.map { matchesRegexOrContains($0) } ?? false
+
+        case .capcode:
+            return post.capcode.map { matchesRegexOrContains($0) } ?? false
+
+        case .passDate:
+            return post.passDate.map { matchesRegexOrContains($0) } ?? false
+
+        case .dimensions:
+            return post.imageDimensions.map { matchesRegexOrContains($0) } ?? false
+
+        case .fileSize:
+            return post.imageFileSize.map { matchesRegexOrContains($0) } ?? false
+
+        case .md5:
+            return post.fileHash.map { matchesExact($0, against: value) } ?? false
+        }
+    }
+
+    private var defaultReason: String {
+        switch filterType {
+        case .xtGeneral:
+            let fields = xtOptions?.generalFieldGroups?.map { group in
+                group.map(\.rawValue).joined(separator: "+")
+            }.joined(separator: ",") ?? "general"
+            return "Filtered \(fields) /\(value)/"
+        case .md5:
+            return "Filtered MD5 \(value)"
+        default:
+            return "Filtered \(filterType.displayName) \(value)"
         }
     }
 
@@ -321,7 +553,13 @@ extension AdvancedFilter {
 
     private func matchesRegex(_ content: String) -> Bool {
         do {
-            let options: NSRegularExpression.Options = isCaseSensitive ? [] : .caseInsensitive
+            var options: NSRegularExpression.Options = isCaseSensitive ? [] : .caseInsensitive
+            if xtRegexFlags?.contains("m") == true {
+                options.insert(.anchorsMatchLines)
+            }
+            if xtRegexFlags?.contains("s") == true {
+                options.insert(.dotMatchesLineSeparators)
+            }
             let regex = try NSRegularExpression(pattern: value, options: options)
             let range = NSRange(location: 0, length: content.utf16.count)
             return regex.firstMatch(in: content, options: [], range: range) != nil
@@ -345,6 +583,13 @@ extension AdvancedFilter {
         } else {
             return content.lowercased().contains(filter.lowercased())
         }
+    }
+
+    private func matchesRegexOrContains(_ content: String) -> Bool {
+        if xtOptions != nil || xtRegexFlags != nil {
+            return matchesRegex(content)
+        }
+        return matchesContains(content, against: value)
     }
 
     private func matchesFileType(_ post: PostMetadata) -> Bool {
@@ -371,6 +616,201 @@ extension AdvancedFilter {
         }
         let thresholdSeconds = tu.toSeconds(tv)
         return age > thresholdSeconds
+    }
+
+    private func appliesToPostContext(_ post: PostMetadata) -> Bool {
+        guard let options = xtOptions else { return true }
+
+        let board = post.boardAbv?.lowercased()
+        if let boards = options.boards, !boards.isEmpty {
+            guard let board = board, boards.contains("*") || boards.contains(board) else { return false }
+        }
+        if let excludedBoards = options.excludedBoards, let board = board {
+            if excludedBoards.contains("*") || excludedBoards.contains(board) {
+                return false
+            }
+        }
+
+        switch options.postScope {
+        case .any:
+            break
+        case .repliesOnly:
+            if post.isOP { return false }
+        case .opOnly:
+            if !post.isOP { return false }
+        }
+
+        switch options.fileScope {
+        case .any:
+            break
+        case .withFileOnly:
+            if !post.hasAttachment { return false }
+        case .withoutFileOnly:
+            if post.hasAttachment { return false }
+        }
+
+        return true
+    }
+
+    private func matchesXTGeneral(_ post: PostMetadata) -> Bool {
+        let groups = xtOptions?.generalFieldGroups ?? [[.subject], [.name], [.filename], [.comment]]
+        for group in groups {
+            let joined = group.map { values(for: $0, post: post).joined(separator: "\n") }.joined(separator: "\n")
+            if matchesRegex(joined) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func values(for field: XTFilterField, post: PostMetadata) -> [String] {
+        switch field {
+        case .postID:
+            return [post.postNumber]
+        case .name:
+            return [post.name].compactMap { $0 }
+        case .uniqueID:
+            return [post.posterId].compactMap { $0 }
+        case .tripcode:
+            return [post.tripCode].compactMap { $0 }
+        case .capcode:
+            return [post.capcode].compactMap { $0 }
+        case .pass:
+            return [post.passDate].compactMap { $0 }
+        case .email:
+            return [post.email].compactMap { $0 }
+        case .subject:
+            return [post.subject ?? (post.isOP ? "" : nil)].compactMap { $0 }
+        case .comment:
+            return [post.comment]
+        case .flag:
+            return [post.countryCode].compactMap { $0 }
+        case .filename:
+            return [post.imageName].compactMap { $0 }
+        case .dimensions:
+            return [post.imageDimensions].compactMap { $0 }
+        case .filesize:
+            return [post.imageFileSize].compactMap { $0 }
+        case .MD5:
+            return [post.fileHash].compactMap { $0 }
+        }
+    }
+}
+
+private struct XTParsedFilterLine {
+    let pattern: String
+    let flags: String
+    let type: FilterType
+    let options: XTFilterOptions
+}
+
+private enum XTFilterLineParser {
+    static func parse(_ line: String, defaultType: FilterType) throws -> XTParsedFilterLine {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("#"), trimmed.first == "/" else {
+            throw XTFilterParseError.missingPattern
+        }
+
+        guard let closingSlash = lastUnescapedSlash(in: trimmed) else {
+            throw XTFilterParseError.missingPattern
+        }
+
+        let patternStart = trimmed.index(after: trimmed.startIndex)
+        let pattern = String(trimmed[patternStart..<closingSlash])
+        let afterSlash = trimmed.index(after: closingSlash)
+        let remainder = String(trimmed[afterSlash...])
+        let flagEnd = remainder.firstIndex(of: ";") ?? remainder.endIndex
+        let flags = String(remainder[..<flagEnd])
+        let optionsText = flagEnd == remainder.endIndex ? "" : String(remainder[flagEnd...])
+        let parsedOptions = try parseOptions(optionsText)
+        return XTParsedFilterLine(pattern: pattern, flags: flags, type: defaultType, options: parsedOptions)
+    }
+
+    private static func lastUnescapedSlash(in line: String) -> String.Index? {
+        var index = line.index(before: line.endIndex)
+        while index > line.startIndex {
+            if line[index] == "/" {
+                let before = line.index(before: index)
+                if line[before] != "\\" {
+                    return index
+                }
+            }
+            index = line.index(before: index)
+        }
+        return nil
+    }
+
+    private static func parseOptions(_ text: String) throws -> XTFilterOptions {
+        var options = XTFilterOptions()
+        let parts = text.split(separator: ";", omittingEmptySubsequences: true)
+        for rawPart in parts {
+            let part = rawPart.trimmingCharacters(in: .whitespacesAndNewlines)
+            if part.hasPrefix("boards:") {
+                options.boards = parseBoards(String(part.dropFirst("boards:".count)))
+            } else if part.hasPrefix("exclude:") {
+                options.excludedBoards = parseBoards(String(part.dropFirst("exclude:".count)))
+            } else if part == "op:no" {
+                options.postScope = .repliesOnly
+            } else if part == "op:only" {
+                options.postScope = .opOnly
+            } else if part == "file:no" {
+                options.fileScope = .withoutFileOnly
+            } else if part == "file:only" {
+                options.fileScope = .withFileOnly
+            } else if part == "stub:yes" {
+                options.stub = true
+            } else if part == "stub:no" {
+                options.stub = false
+            } else if part == "highlight" {
+                options.highlightClass = "filter-highlight"
+                options.pinToTop = true
+                options.hide = false
+            } else if part.hasPrefix("highlight:") {
+                let value = String(part.dropFirst("highlight:".count))
+                options.highlightClass = value.isEmpty ? "filter-highlight" : value
+                options.pinToTop = true
+                options.hide = false
+            } else if part == "top:yes" {
+                options.pinToTop = true
+            } else if part == "top:no" {
+                options.pinToTop = false
+            } else if part == "notify" {
+                options.notify = true
+                options.hide = false
+            } else if part == "poster" {
+                options.samePoster = true
+            } else if part == "replies" {
+                options.recursiveReplies = true
+            } else if part == "hide" {
+                options.hide = true
+            } else if part.hasPrefix("reason:") {
+                options.reason = String(part.dropFirst("reason:".count))
+            } else if part.hasPrefix("type:") {
+                options.generalFieldGroups = try parseFieldGroups(String(part.dropFirst("type:".count)))
+            }
+        }
+        return options
+    }
+
+    private static func parseBoards(_ raw: String) -> [String] {
+        return raw.split(separator: ",").map { part in
+            let board = part.split(separator: ":").last.map(String.init) ?? String(part)
+            return board.trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+                .replacingOccurrences(of: "/", with: "")
+        }.filter { !$0.isEmpty }
+    }
+
+    private static func parseFieldGroups(_ raw: String) throws -> [[XTFilterField]] {
+        try raw.split(separator: ",").map { group in
+            try group.split(separator: "+").map { rawField in
+                let name = String(rawField).trimmingCharacters(in: .whitespacesAndNewlines)
+                guard let field = XTFilterField(rawValue: name) else {
+                    throw XTFilterParseError.unknownField(name)
+                }
+                return field
+            }
+        }.filter { !$0.isEmpty }
     }
 }
 

--- a/Channer/Utilities/ContentFilterManager.swift
+++ b/Channer/Utilities/ContentFilterManager.swift
@@ -1,5 +1,27 @@
 import Foundation
 
+struct ContentFilterResult: Equatable {
+    var isFiltered: Bool
+    var showStub: Bool
+    var reasons: [String]
+    var matchedFilterIDs: [UUID]
+    var highlightClasses: [String]
+    var pinToTop: Bool
+    var notify: Bool
+    var filteredBacklinksVisible: Bool
+
+    static let visible = ContentFilterResult(
+        isFiltered: false,
+        showStub: false,
+        reasons: [],
+        matchedFilterIDs: [],
+        highlightClasses: [],
+        pinToTop: false,
+        notify: false,
+        filteredBacklinksVisible: false
+    )
+}
+
 /// Manages content filtering settings and operations for Channer
 /// Supports both legacy simple filters and advanced filters (regex, file type, country, trip code, time-based)
 class ContentFilterManager {
@@ -15,6 +37,11 @@ class ContentFilterManager {
     // MARK: - Constants (Advanced)
     private let advancedFiltersKey = "advanced_content_filters"
     private let advancedFilterEnabledKey = "advanced_filter_enabled"
+    private let showStubsKey = "advanced_filter_show_stubs"
+    private let showFilterReasonKey = "advanced_filter_show_reason"
+    private let filteredBacklinksKey = "advanced_filter_filtered_backlinks"
+    private let recursiveHidingKey = "advanced_filter_recursive_hiding"
+    private let anonymizeModeKey = "advanced_filter_anonymize_mode"
 
     // MARK: - Thread Safety
     private let queue = DispatchQueue(label: "com.channer.contentfilter", attributes: .concurrent)
@@ -26,7 +53,7 @@ class ContentFilterManager {
             queue.sync { _advancedFilters }
         }
         set {
-            queue.async(flags: .barrier) { [weak self] in
+            queue.sync(flags: .barrier) { [weak self] in
                 self?._advancedFilters = newValue
             }
         }
@@ -40,6 +67,21 @@ class ContentFilterManager {
         }
         if UserDefaults.standard.object(forKey: advancedFilterEnabledKey) == nil {
             UserDefaults.standard.set(true, forKey: advancedFilterEnabledKey)
+        }
+        if UserDefaults.standard.object(forKey: showStubsKey) == nil {
+            UserDefaults.standard.set(true, forKey: showStubsKey)
+        }
+        if UserDefaults.standard.object(forKey: showFilterReasonKey) == nil {
+            UserDefaults.standard.set(true, forKey: showFilterReasonKey)
+        }
+        if UserDefaults.standard.object(forKey: filteredBacklinksKey) == nil {
+            UserDefaults.standard.set(false, forKey: filteredBacklinksKey)
+        }
+        if UserDefaults.standard.object(forKey: recursiveHidingKey) == nil {
+            UserDefaults.standard.set(true, forKey: recursiveHidingKey)
+        }
+        if UserDefaults.standard.object(forKey: anonymizeModeKey) == nil {
+            UserDefaults.standard.set(false, forKey: anonymizeModeKey)
         }
 
         // Load advanced filters into cache
@@ -154,6 +196,47 @@ class ContentFilterManager {
         UserDefaults.standard.set(enabled, forKey: advancedFilterEnabledKey)
     }
 
+    func showStubsForFilteredPosts() -> Bool {
+        return UserDefaults.standard.bool(forKey: showStubsKey)
+    }
+
+    func setShowStubsForFilteredPosts(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: showStubsKey)
+    }
+
+    func showFilterReasons() -> Bool {
+        return UserDefaults.standard.bool(forKey: showFilterReasonKey)
+    }
+
+    func setShowFilterReasons(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: showFilterReasonKey)
+    }
+
+    func showFilteredBacklinks() -> Bool {
+        return UserDefaults.standard.bool(forKey: filteredBacklinksKey)
+    }
+
+    func setShowFilteredBacklinks(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: filteredBacklinksKey)
+    }
+
+    func isRecursiveHidingEnabled() -> Bool {
+        return UserDefaults.standard.bool(forKey: recursiveHidingKey)
+    }
+
+    func setRecursiveHidingEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: recursiveHidingKey)
+    }
+
+    func isAnonymizeModeEnabled() -> Bool {
+        return UserDefaults.standard.bool(forKey: anonymizeModeKey)
+    }
+
+    func setAnonymizeModeEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: anonymizeModeKey)
+        NotificationCenter.default.post(name: .advancedFiltersDidChange, object: nil)
+    }
+
     /// Gets all advanced filters
     func getAdvancedFilters() -> [AdvancedFilter] {
         return advancedFilters
@@ -186,6 +269,24 @@ class ContentFilterManager {
 
         NotificationCenter.default.post(name: .advancedFiltersDidChange, object: nil)
         return true
+    }
+
+    @discardableResult
+    func addXTFilterLine(_ line: String, type: FilterType = .xtGeneral) -> Bool {
+        do {
+            let filter = try AdvancedFilter.xt(line, type: type)
+            return addAdvancedFilter(filter)
+        } catch {
+            print("Failed to parse XT filter line: \(error)")
+            return false
+        }
+    }
+
+    @discardableResult
+    func quickFilterMD5(_ hash: String) -> Bool {
+        let cleaned = hash.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return false }
+        return addAdvancedFilter(.md5(cleaned))
     }
 
     /// Removes an advanced filter by ID
@@ -257,6 +358,10 @@ class ContentFilterManager {
     /// - Parameter post: The post metadata to check
     /// - Returns: True if the post should be hidden
     func shouldFilter(post: PostMetadata) -> Bool {
+        return filterResult(for: post).isFiltered
+    }
+
+    func filterResult(for post: PostMetadata) -> ContentFilterResult {
         // Check legacy filters first
         if isFilteringEnabled() {
             let legacyFilters = getAllFilters()
@@ -264,7 +369,7 @@ class ContentFilterManager {
             // Check keyword filters
             for keyword in legacyFilters.keywords {
                 if post.comment.lowercased().contains(keyword.lowercased()) {
-                    return true
+                    return legacyFilterResult(reason: "Filtered keyword \(keyword)")
                 }
             }
 
@@ -272,7 +377,7 @@ class ContentFilterManager {
             if let posterId = post.posterId {
                 for poster in legacyFilters.posters {
                     if posterId.lowercased().contains(poster.lowercased()) {
-                        return true
+                        return legacyFilterResult(reason: "Filtered poster \(poster)")
                     }
                 }
             }
@@ -281,7 +386,7 @@ class ContentFilterManager {
             if let imageUrl = post.imageUrl {
                 for image in legacyFilters.images {
                     if imageUrl.lowercased().contains(image.lowercased()) {
-                        return true
+                        return legacyFilterResult(reason: "Filtered image \(image)")
                     }
                 }
             }
@@ -299,20 +404,136 @@ class ContentFilterManager {
             if !whitelistFilters.isEmpty {
                 let matchesWhitelist = whitelistFilters.contains { $0.matches(post: post) }
                 if !matchesWhitelist {
-                    return true  // Hide if doesn't match whitelist
+                    return legacyFilterResult(reason: "Filtered by whitelist")
                 }
             }
 
             // Check blacklist filters
+            var result = ContentFilterResult.visible
             for filter in blacklistFilters {
-                if filter.matches(post: post) {
+                if let effect = filter.matchEffect(post: post, defaultShowStub: showStubsForFilteredPosts()) {
                     recordFilterHit(id: filter.id)
-                    return true
+                    result.matchedFilterIDs.append(effect.filterID)
+                    if let highlightClass = effect.highlightClass, !result.highlightClasses.contains(highlightClass) {
+                        result.highlightClasses.append(highlightClass)
+                    }
+                    result.pinToTop = result.pinToTop || effect.pinToTop
+                    result.notify = result.notify || effect.notify
+
+                    guard effect.shouldHide else { continue }
+                    result.isFiltered = true
+                    result.showStub = effect.showStub ?? showStubsForFilteredPosts()
+                    result.filteredBacklinksVisible = showFilteredBacklinks()
+                    if showFilterReasons(), let reason = effect.reason {
+                        result.reasons.append(reason)
+                    }
+                }
+            }
+            if result.isFiltered || !result.highlightClasses.isEmpty || result.pinToTop || result.notify {
+                return result
+            }
+        }
+
+        return .visible
+    }
+
+    func filterResults(for posts: [PostMetadata]) -> [String: ContentFilterResult] {
+        var results: [String: ContentFilterResult] = [:]
+        var recursiveRoots = Set<String>()
+        var hiddenPosterIds = Set<String>()
+
+        for post in posts {
+            let result = filterResult(for: post)
+            guard result.isFiltered || result.pinToTop || result.notify || !result.highlightClasses.isEmpty else { continue }
+            results[post.postNumber] = result
+
+            let matchedFilters = getEnabledAdvancedFilters().filter { result.matchedFilterIDs.contains($0.id) }
+            if matchedFilters.contains(where: { $0.xtOptions?.recursiveReplies == true }) {
+                recursiveRoots.insert(post.postNumber)
+            }
+            if matchedFilters.contains(where: { $0.xtOptions?.samePoster == true }),
+               let posterId = post.posterId,
+               !posterId.isEmpty {
+                hiddenPosterIds.insert(posterId)
+            }
+        }
+
+        if !hiddenPosterIds.isEmpty {
+            for post in posts where hiddenPosterIds.contains(post.posterId ?? "") && results[post.postNumber]?.isFiltered != true {
+                results[post.postNumber] = recursiveResult(reason: "Hidden because it is the same poster as a filtered post")
+            }
+        }
+
+        if isRecursiveHidingEnabled(), !recursiveRoots.isEmpty {
+            var hidden = recursiveRoots
+            var changed = true
+            while changed {
+                changed = false
+                for post in posts where results[post.postNumber]?.isFiltered != true {
+                    if post.quotedPostNumbers.contains(where: { hidden.contains($0) }) {
+                        results[post.postNumber] = recursiveResult(reason: "Hidden recursively from filtered post")
+                        hidden.insert(post.postNumber)
+                        changed = true
+                    }
                 }
             }
         }
 
-        return false
+        return results
+    }
+
+    func anonymized(post: PostMetadata) -> PostMetadata {
+        guard isAnonymizeModeEnabled() else { return post }
+        return PostMetadata(
+            postNumber: post.postNumber,
+            comment: post.comment,
+            posterId: nil,
+            tripCode: nil,
+            countryCode: post.countryCode,
+            countryName: post.countryName,
+            timestamp: post.timestamp,
+            imageUrl: post.imageUrl,
+            imageExtension: post.imageExtension,
+            imageName: post.imageName,
+            fileHash: post.fileHash,
+            boardAbv: post.boardAbv,
+            threadNumber: post.threadNumber,
+            subject: post.subject,
+            name: "Anonymous",
+            email: nil,
+            capcode: nil,
+            passDate: nil,
+            imageDimensions: post.imageDimensions,
+            imageFileSize: post.imageFileSize,
+            isOP: post.isOP,
+            isTopThread: post.isTopThread
+        )
+    }
+
+    private func legacyFilterResult(reason: String) -> ContentFilterResult {
+        return ContentFilterResult(
+            isFiltered: true,
+            showStub: showStubsForFilteredPosts(),
+            reasons: showFilterReasons() ? [reason] : [],
+            matchedFilterIDs: [],
+            highlightClasses: [],
+            pinToTop: false,
+            notify: false,
+            filteredBacklinksVisible: showFilteredBacklinks()
+        )
+    }
+
+    private func recursiveResult(reason: String) -> ContentFilterResult {
+        return ContentFilterResult(
+            isFiltered: true,
+            showStub: showStubsForFilteredPosts(),
+            reasons: showFilterReasons() ? [reason] : [],
+            matchedFilterIDs: [],
+            highlightClasses: [],
+            pinToTop: false,
+            notify: false,
+            filteredBacklinksVisible: showFilteredBacklinks()
+        )
     }
 
     /// Validates a regex pattern

--- a/Channer/Utilities/ThreadDataHelper.swift
+++ b/Channer/Utilities/ThreadDataHelper.swift
@@ -11,20 +11,15 @@ class ThreadDataHelper {
     /// - Returns: Filtered thread data or original data if filtering fails/disabled
     static func applyContentFiltering(to threadData: Data) -> Data? {
         // Only apply filtering if it's enabled
-        if !ContentFilterManager.shared.isFilteringEnabled() {
+        if !ContentFilterManager.shared.isFilteringEnabled() && !ContentFilterManager.shared.isAdvancedFilteringEnabled() {
             return threadData
         }
         
         do {
             // Parse the JSON data
-            _ = try JSON(data: threadData)
-            
-            // Apply filtering to the parsed JSON
-            // TODO: Implement filterPosts method in ContentFilterManager
-            // let filteredJSON = ContentFilterManager.shared.filterPosts(in: json)
-            
-            // For now, return original data
-            return threadData
+            let json = try JSON(data: threadData)
+            let filteredJSON = filterPosts(in: json)
+            return try filteredJSON.rawData()
         } catch {
             print("Error applying content filtering: \(error)")
             return threadData // Return original data if filtering fails
@@ -39,13 +34,19 @@ class ThreadDataHelper {
     /// - Returns: True if thread should be filtered/hidden, false otherwise
     static func shouldFilterThread(boardAbv: String, threadNumber: String, threadJSON: JSON) -> Bool {
         // Only check filtering if it's enabled
-        if !ContentFilterManager.shared.isFilteringEnabled() {
+        if !ContentFilterManager.shared.isFilteringEnabled() && !ContentFilterManager.shared.isAdvancedFilteringEnabled() {
             return false
         }
         
-        // TODO: Implement shouldFilterThread method in ContentFilterManager
-        // return ContentFilterManager.shared.shouldFilterThread(threadJSON)
-        return false
+        let firstPost = threadJSON["posts"].array?.first ?? threadJSON
+        let metadata = postMetadata(
+            from: firstPost,
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            isOP: true,
+            isTopThread: true
+        )
+        return ContentFilterManager.shared.filterResult(for: metadata).isFiltered
     }
     
     /// Applies content filtering to a collection of thread JSON objects
@@ -53,12 +54,121 @@ class ThreadDataHelper {
     /// - Returns: Filtered array with unwanted threads removed
     static func applyFiltering(to threads: [JSON]) -> [JSON] {
         // Only apply filtering if it's enabled
-        if !ContentFilterManager.shared.isFilteringEnabled() {
+        if !ContentFilterManager.shared.isFilteringEnabled() && !ContentFilterManager.shared.isAdvancedFilteringEnabled() {
             return threads
         }
         
-        // TODO: Implement shouldFilterThread method in ContentFilterManager
-        // return threads.filter { !ContentFilterManager.shared.shouldFilterThread($0) }
-        return threads
+        return threads.filter { thread in
+            let boardAbv = thread["board"].stringValue
+            let post = thread["posts"].array?.first ?? thread
+            let threadNumber = post["no"].stringValue
+            return !shouldFilterThread(boardAbv: boardAbv, threadNumber: threadNumber, threadJSON: thread)
+        }
+    }
+
+    static func filterPosts(in json: JSON, boardAbv: String? = nil, threadNumber: String? = nil) -> JSON {
+        var filteredJSON = json
+        let posts = json["posts"].arrayValue
+        guard !posts.isEmpty else { return json }
+
+        let resolvedBoard = boardAbv ?? json["board"].string
+        let resolvedThread = threadNumber ?? posts.first?["no"].stringValue
+        let metadata = posts.enumerated().map { index, post in
+            postMetadata(
+                from: post,
+                boardAbv: resolvedBoard,
+                threadNumber: resolvedThread,
+                isOP: index == 0,
+                isTopThread: index == 0
+            )
+        }
+
+        let results = ContentFilterManager.shared.filterResults(for: metadata)
+        var outputPosts: [Any] = []
+        for (index, post) in posts.enumerated() {
+            let postNo = metadata[index].postNumber
+            guard let result = results[postNo], result.isFiltered else {
+                outputPosts.append(post.object)
+                continue
+            }
+
+            if result.showStub {
+                var stub = post
+                let reason = result.reasons.joined(separator: " & ")
+                stub["com"].string = reason.isEmpty ? "Filtered" : "Filtered: \(reason)"
+                stub["filename"].string = nil
+                stub["tim"].int = nil
+                stub["ext"].string = nil
+                outputPosts.append(stub.object)
+            }
+        }
+        filteredJSON["posts"].arrayObject = outputPosts
+        return filteredJSON
+    }
+
+    static func postMetadata(
+        from post: JSON,
+        boardAbv: String?,
+        threadNumber: String?,
+        isOP: Bool,
+        isTopThread: Bool = false
+    ) -> PostMetadata {
+        let ext = post["ext"].string
+        let filename = post["filename"].string
+        let displayFilename: String?
+        if let filename = filename, let ext = ext {
+            displayFilename = "\(filename)\(ext)"
+        } else {
+            displayFilename = filename
+        }
+
+        let imageURL: String?
+        if let boardAbv = boardAbv,
+           let tim = post["tim"].int64,
+           let ext = ext {
+            imageURL = "https://i.4cdn.org/\(boardAbv)/\(tim)\(ext)"
+        } else {
+            imageURL = nil
+        }
+
+        let dimensions: String?
+        if let width = post["w"].int, let height = post["h"].int {
+            dimensions = "\(width)x\(height)"
+        } else {
+            dimensions = nil
+        }
+
+        let fileSize = post["fsize"].int.map { "\($0)" }
+
+        return PostMetadata(
+            postNumber: post["no"].stringValue,
+            comment: post["com"].stringValue,
+            posterId: post["id"].string?.nilIfEmpty,
+            tripCode: post["trip"].string?.nilIfEmpty,
+            countryCode: post["country"].string?.nilIfEmpty,
+            countryName: post["country_name"].string?.nilIfEmpty,
+            timestamp: post["time"].int,
+            imageUrl: imageURL,
+            imageExtension: ext,
+            imageName: displayFilename,
+            fileHash: post["md5"].string?.nilIfEmpty,
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            subject: post["sub"].string?.nilIfEmpty,
+            name: post["name"].string?.nilIfEmpty,
+            email: post["email"].string?.nilIfEmpty,
+            capcode: post["capcode"].string?.nilIfEmpty,
+            passDate: post["since4pass"].string?.nilIfEmpty,
+            imageDimensions: dimensions,
+            imageFileSize: fileSize,
+            isOP: isOP,
+            isTopThread: isTopThread
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        return isEmpty ? nil : self
     }
 }

--- a/Channer/ViewControllers/Board/boardTV.swift
+++ b/Channer/ViewControllers/Board/boardTV.swift
@@ -977,27 +977,7 @@ class boardTV: UITableViewController, UISearchBarDelegate, BottomToolbarSearchDi
 
             self.threadData = Array(dedupedThreads.values).sorted { Int($0.number) ?? 0 > Int($1.number) ?? 0 }
             
-            // Apply content filtering if enabled
-            if let utilContentFilterManager = NSClassFromString("Channer.ContentFilterManager") as? NSObject.Type,
-               let manager = utilContentFilterManager.value(forKeyPath: "shared") as? NSObject,
-               let isFilteringEnabled = manager.perform(NSSelectorFromString("isFilteringEnabled"))?.takeUnretainedValue() as? Bool,
-               isFilteringEnabled {
-                
-                // Get keyword filters through KVC
-                if let getAllFilters = manager.perform(NSSelectorFromString("getAllFilters"))?.takeUnretainedValue() as? (keywords: [String], posters: [String], images: [String]),
-                   !getAllFilters.keywords.isEmpty {
-                    
-                    let keywordFilters = getAllFilters.keywords
-                    self.filteredThreadData = self.threadData.filter { thread in
-                        let threadContent = (thread.title + " " + thread.comment).lowercased()
-                        return !keywordFilters.contains { threadContent.contains($0.lowercased()) }
-                    }
-                } else {
-                    self.filteredThreadData = self.threadData
-                }
-            } else {
-                self.filteredThreadData = self.threadData
-            }
+            self.filteredThreadData = self.applyContentFilters(to: self.threadData)
 
             self.updateFilterCache()
             self.tableView.reloadData()
@@ -1008,28 +988,7 @@ class boardTV: UITableViewController, UISearchBarDelegate, BottomToolbarSearchDi
         // Loads favorite threads.
         print("boardTV - loadFavorites")
         threadData = FavoritesManager.shared.loadFavorites()
-        
-        // Apply content filtering if enabled
-        if let utilContentFilterManager = NSClassFromString("Channer.ContentFilterManager") as? NSObject.Type,
-           let manager = utilContentFilterManager.value(forKeyPath: "shared") as? NSObject,
-           let isFilteringEnabled = manager.perform(NSSelectorFromString("isFilteringEnabled"))?.takeUnretainedValue() as? Bool,
-           isFilteringEnabled {
-            
-            // Get keyword filters through KVC
-            if let getAllFilters = manager.perform(NSSelectorFromString("getAllFilters"))?.takeUnretainedValue() as? (keywords: [String], posters: [String], images: [String]),
-               !getAllFilters.keywords.isEmpty {
-                
-                let keywordFilters = getAllFilters.keywords
-                filteredThreadData = threadData.filter { thread in
-                    let threadContent = (thread.title + " " + thread.comment).lowercased()
-                    return !keywordFilters.contains { threadContent.contains($0.lowercased()) }
-                }
-            } else {
-                filteredThreadData = threadData
-            }
-        } else {
-            filteredThreadData = threadData
-        }
+        filteredThreadData = applyContentFilters(to: threadData)
 
         // Update filter cache and reload the table view
         updateFilterCache()
@@ -1043,30 +1002,61 @@ class boardTV: UITableViewController, UISearchBarDelegate, BottomToolbarSearchDi
     private func updateFilterCache() {
         filteredThreadNumbers.removeAll()
 
-        // Check if content filtering is enabled using direct access
-        guard ContentFilterManager.shared.isFilteringEnabled() else {
+        let manager = ContentFilterManager.shared
+        guard manager.isFilteringEnabled() || manager.isAdvancedFilteringEnabled() else {
             filterCacheValid = true
             return
         }
 
-        let filters = ContentFilterManager.shared.getAllFilters()
-        guard !filters.keywords.isEmpty else {
-            filterCacheValid = true
-            return
-        }
-
-        // Pre-compute lowercased keywords once
-        let lowercasedKeywords = filters.keywords.map { $0.lowercased() }
-
-        // Cache which threads match filters
         for thread in filteredThreadData {
-            let threadContent = (thread.title + " " + thread.comment).lowercased()
-            if lowercasedKeywords.contains(where: { threadContent.contains($0) }) {
+            let metadata = postMetadata(for: thread)
+            if manager.filterResult(for: metadata).isFiltered {
                 filteredThreadNumbers.insert(thread.number)
             }
         }
 
         filterCacheValid = true
+    }
+
+    private func applyContentFilters(to threads: [ThreadData]) -> [ThreadData] {
+        let manager = ContentFilterManager.shared
+        guard manager.isFilteringEnabled() || manager.isAdvancedFilteringEnabled() else {
+            return threads
+        }
+
+        let visibleThreads = threads.compactMap { thread in
+            let result = manager.filterResult(for: postMetadata(for: thread))
+            return result.isFiltered && !result.showStub ? nil : thread
+        }
+        guard visibleThreads.contains(where: { manager.filterResult(for: postMetadata(for: $0)).pinToTop }) else {
+            return visibleThreads
+        }
+
+        return visibleThreads.sorted { lhs, rhs in
+            let lhsResult = manager.filterResult(for: postMetadata(for: lhs))
+            let rhsResult = manager.filterResult(for: postMetadata(for: rhs))
+            if lhsResult.pinToTop != rhsResult.pinToTop {
+                return lhsResult.pinToTop
+            }
+            return (lhs.bumpIndex ?? Int.max) < (rhs.bumpIndex ?? Int.max)
+        }
+    }
+
+    private func postMetadata(for thread: ThreadData) -> PostMetadata {
+        let ext = URL(string: thread.imageUrl)?.pathExtension
+        return PostMetadata(
+            postNumber: thread.number,
+            comment: thread.comment,
+            timestamp: thread.lastReplyTime,
+            imageUrl: thread.imageUrl.isEmpty ? nil : thread.imageUrl,
+            imageExtension: ext.map { ".\($0)" },
+            boardAbv: thread.boardAbv,
+            threadNumber: thread.number,
+            subject: thread.title.isEmpty ? nil : thread.title,
+            name: nil,
+            isOP: true,
+            isTopThread: (thread.bumpIndex ?? Int.max) == 0
+        )
     }
 
     // MARK: - TableView DataSource Methods

--- a/Channer/ViewControllers/Board/threadCatalogCV.swift
+++ b/Channer/ViewControllers/Board/threadCatalogCV.swift
@@ -153,13 +153,20 @@ class threadCatalogCV: UICollectionViewController, UICollectionViewDelegateFlowL
     private func applyFiltersAndSearch() {
         var results = threadData
 
-        if ContentFilterManager.shared.isFilteringEnabled() {
-            let filters = ContentFilterManager.shared.getAllFilters()
-            if !filters.keywords.isEmpty {
-                let lowercasedKeywords = filters.keywords.map { $0.lowercased() }
-                results = results.filter { thread in
-                    let threadContent = (thread.title + " " + thread.comment).lowercased()
-                    return !lowercasedKeywords.contains { threadContent.contains($0) }
+        let manager = ContentFilterManager.shared
+        if manager.isFilteringEnabled() || manager.isAdvancedFilteringEnabled() {
+            results = results.compactMap { thread in
+                let result = manager.filterResult(for: postMetadata(for: thread))
+                return result.isFiltered && !result.showStub ? nil : thread
+            }
+            if results.contains(where: { manager.filterResult(for: postMetadata(for: $0)).pinToTop }) {
+                results.sort { lhs, rhs in
+                    let lhsResult = manager.filterResult(for: postMetadata(for: lhs))
+                    let rhsResult = manager.filterResult(for: postMetadata(for: rhs))
+                    if lhsResult.pinToTop != rhsResult.pinToTop {
+                        return lhsResult.pinToTop
+                    }
+                    return (lhs.bumpIndex ?? Int.max) < (rhs.bumpIndex ?? Int.max)
                 }
             }
         }
@@ -174,6 +181,22 @@ class threadCatalogCV: UICollectionViewController, UICollectionViewDelegateFlowL
         }
 
         filteredThreadData = results
+    }
+
+    private func postMetadata(for thread: ThreadData) -> PostMetadata {
+        let ext = URL(string: thread.imageUrl)?.pathExtension
+        return PostMetadata(
+            postNumber: thread.number,
+            comment: thread.comment,
+            timestamp: thread.lastReplyTime,
+            imageUrl: thread.imageUrl.isEmpty ? nil : thread.imageUrl,
+            imageExtension: ext.map { ".\($0)" },
+            boardAbv: thread.boardAbv,
+            threadNumber: thread.number,
+            subject: thread.title.isEmpty ? nil : thread.title,
+            isOP: true,
+            isTopThread: (thread.bumpIndex ?? Int.max) == 0
+        )
     }
 
     // MARK: - Data Loading

--- a/Channer/ViewControllers/Home/AdvancedFilterViewController.swift
+++ b/Channer/ViewControllers/Home/AdvancedFilterViewController.swift
@@ -14,7 +14,9 @@ class AdvancedFilterViewController: UIViewController {
     // Section indices
     private enum Section: Int, CaseIterable {
         case globalSettings = 0
+        case xtFilters
         case regexFilters
+        case md5Filters
         case fileTypeFilters
         case countryFilters
         case tripCodeFilters
@@ -23,7 +25,9 @@ class AdvancedFilterViewController: UIViewController {
         var title: String {
             switch self {
             case .globalSettings: return "Global Settings"
+            case .xtFilters: return "XT Filters"
             case .regexFilters: return "Regex Filters"
+            case .md5Filters: return "MD5 Filters"
             case .fileTypeFilters: return "File Type Filters"
             case .countryFilters: return "Country Flag Filters"
             case .tripCodeFilters: return "Trip Code Filters"
@@ -33,8 +37,10 @@ class AdvancedFilterViewController: UIViewController {
 
         var footer: String {
             switch self {
-            case .globalSettings: return "Enable or disable all advanced filtering globally."
+            case .globalSettings: return "XT-compatible behavior for filtering, stubs, reasons, backlinks, recursion, and anonymized names."
+            case .xtFilters: return "Add XT lines like /general/i;boards:v;op:only;type:subject,comment;reason:General."
             case .regexFilters: return "Filter posts matching regular expression patterns."
+            case .md5Filters: return "Exact MD5 filters match XT's image MD5 behavior and quick filter entries."
             case .fileTypeFilters: return "Filter posts based on attachment type (videos, images, GIFs)."
             case .countryFilters: return "Filter posts by country flag. Use whitelist to only show specific countries."
             case .tripCodeFilters: return "Filter posts by trip code. Use whitelist to only show specific tripcodes."
@@ -45,7 +51,9 @@ class AdvancedFilterViewController: UIViewController {
         var filterType: FilterType? {
             switch self {
             case .globalSettings: return nil
+            case .xtFilters: return .xtGeneral
             case .regexFilters: return .regex
+            case .md5Filters: return .md5
             case .fileTypeFilters: return .fileType
             case .countryFilters: return .countryFlag
             case .tripCodeFilters: return .tripCode
@@ -142,6 +150,10 @@ class AdvancedFilterViewController: UIViewController {
     }
 
     private func filters(for section: Section) -> [AdvancedFilter] {
+        if section == .xtFilters {
+            let xtTypes: Set<FilterType> = [.xtGeneral, .subject, .email, .capcode, .passDate, .dimensions, .fileSize]
+            return advancedFilters.filter { xtTypes.contains($0.filterType) }
+        }
         guard let type = section.filterType else { return [] }
         return advancedFilters.filter { $0.filterType == type }
     }
@@ -157,6 +169,14 @@ class AdvancedFilterViewController: UIViewController {
 
         alert.addAction(UIAlertAction(title: "Regex Pattern", style: .default) { [weak self] _ in
             self?.showAddRegexFilter()
+        })
+
+        alert.addAction(UIAlertAction(title: "XT Filter Line", style: .default) { [weak self] _ in
+            self?.showAddXTFilter()
+        })
+
+        alert.addAction(UIAlertAction(title: "MD5", style: .default) { [weak self] _ in
+            self?.showAddMD5Filter()
         })
 
         alert.addAction(UIAlertAction(title: "File Type", style: .default) { [weak self] _ in
@@ -185,6 +205,56 @@ class AdvancedFilterViewController: UIViewController {
     }
 
     // MARK: - Add Filter Dialogs
+
+    private func showAddXTFilter() {
+        let alert = UIAlertController(
+            title: "Add XT Filter",
+            message: "Use /pattern/flags;options syntax",
+            preferredStyle: .alert
+        )
+
+        alert.addTextField { textField in
+            textField.placeholder = "/general/i;boards:v;op:only;reason:General"
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+        }
+
+        alert.addAction(UIAlertAction(title: "Add", style: .default) { [weak self] _ in
+            guard let line = alert.textFields?.first?.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !line.isEmpty else { return }
+            if !ContentFilterManager.shared.addXTFilterLine(line) {
+                self?.showError("Invalid XT filter line")
+            }
+        })
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func showAddMD5Filter() {
+        let alert = UIAlertController(
+            title: "Add MD5 Filter",
+            message: "Enter an image MD5 hash",
+            preferredStyle: .alert
+        )
+
+        alert.addTextField { textField in
+            textField.placeholder = "Base64 MD5"
+            textField.autocapitalizationType = .none
+            textField.autocorrectionType = .no
+        }
+
+        alert.addAction(UIAlertAction(title: "Add", style: .default) { [weak self] _ in
+            guard let hash = alert.textFields?.first?.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !hash.isEmpty else { return }
+            if !ContentFilterManager.shared.quickFilterMD5(hash) {
+                self?.showError("Invalid MD5 hash")
+            }
+        })
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
 
     private func showAddRegexFilter() {
         let alert = UIAlertController(
@@ -347,9 +417,24 @@ class AdvancedFilterViewController: UIViewController {
     // MARK: - Toggle Actions
 
     @objc private func toggleAdvancedFiltering(_ sender: UISwitch) {
-        contentFilterManager.setAdvancedFilteringEnabled(sender.isOn)
+        switch sender.tag {
+        case 0:
+            contentFilterManager.setAdvancedFilteringEnabled(sender.isOn)
+        case 1:
+            contentFilterManager.setShowStubsForFilteredPosts(sender.isOn)
+        case 2:
+            contentFilterManager.setShowFilterReasons(sender.isOn)
+        case 3:
+            contentFilterManager.setShowFilteredBacklinks(sender.isOn)
+        case 4:
+            contentFilterManager.setRecursiveHidingEnabled(sender.isOn)
+        case 5:
+            contentFilterManager.setAnonymizeModeEnabled(sender.isOn)
+        default:
+            break
+        }
 
-        let message = sender.isOn ? "Advanced filtering enabled" : "Advanced filtering disabled"
+        let message = sender.isOn ? "Enabled" : "Disabled"
         showBriefMessage(message)
     }
 
@@ -393,7 +478,7 @@ extension AdvancedFilterViewController: UITableViewDataSource {
         guard let sectionType = Section(rawValue: section) else { return 0 }
 
         if sectionType == .globalSettings {
-            return 1
+            return 6
         }
 
         return filters(for: sectionType).count
@@ -406,9 +491,19 @@ extension AdvancedFilterViewController: UITableViewDataSource {
 
         if section == .globalSettings {
             let cell = tableView.dequeueReusableCell(withIdentifier: "SwitchCell", for: indexPath) as! SwitchTableViewCell
-            cell.textLabel?.text = "Enable Advanced Filtering"
+            let rows: [(String, Bool)] = [
+                ("Enable Advanced Filtering", contentFilterManager.isAdvancedFilteringEnabled()),
+                ("Show Stubs", contentFilterManager.showStubsForFilteredPosts()),
+                ("Show Filter Reasons", contentFilterManager.showFilterReasons()),
+                ("Show Filtered Backlinks", contentFilterManager.showFilteredBacklinks()),
+                ("Recursive Hiding", contentFilterManager.isRecursiveHidingEnabled()),
+                ("Anonymize Mode", contentFilterManager.isAnonymizeModeEnabled())
+            ]
+            let row = rows[indexPath.row]
+            cell.textLabel?.text = row.0
             cell.textLabel?.textColor = ThemeManager.shared.primaryTextColor
-            cell.switchControl.isOn = contentFilterManager.isAdvancedFilteringEnabled()
+            cell.switchControl.isOn = row.1
+            cell.switchControl.tag = indexPath.row
             cell.switchControl.removeTarget(nil, action: nil, for: .valueChanged)
             cell.switchControl.addTarget(self, action: #selector(toggleAdvancedFiltering(_:)), for: .valueChanged)
             cell.backgroundColor = ThemeManager.shared.cellBackgroundColor

--- a/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
+++ b/Channer/ViewControllers/Thread Replies/threadRepliesTV.swift
@@ -38,6 +38,12 @@ class Reachability {
     }
 }
 
+private extension String {
+    var nilIfEmptyForFiltering: String? {
+        return isEmpty ? nil : self
+    }
+}
+
 // MARK: - Preloading Pipeline
 /// Extensions for optimizing thread content loading and caching
 extension threadRepliesTV {
@@ -315,6 +321,8 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     var fullThreadPostMetadataList: [PostMetadata]?
     private var replyViewRootPostNumber: String?
     var filteredReplyIndices = Set<Int>() // Track indices of filtered replies
+    private var hiddenFilteredReplyIndices = Set<Int>()
+    private var filteredReplyReasons: [Int: String] = [:]
     var totalImagesInThread: Int = 0
 
     // Post metadata for advanced filtering
@@ -1606,11 +1614,9 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     // MARK: - Table View Data Source Methods
     /// Methods required to display data in the table view
     private func actualIndex(for indexPath: IndexPath) -> Int? {
-        guard isSearchActive && !searchText.isEmpty else { return indexPath.row }
-
         var visibleIndex = 0
         for dataIndex in 0..<threadReplies.count {
-            if !searchFilteredIndices.contains(dataIndex) {
+            if !isRowHiddenByActiveFilters(dataIndex) {
                 if visibleIndex == indexPath.row {
                     return dataIndex
                 }
@@ -1629,13 +1635,15 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         if isLoading {
             return 0
         }
-        
-        // If search is active, only count unfiltered rows
-        if isSearchActive && !searchText.isEmpty {
-            return threadReplies.count - searchFilteredIndices.count
+
+        return (0..<threadReplies.count).filter { !isRowHiddenByActiveFilters($0) }.count
+    }
+
+    private func isRowHiddenByActiveFilters(_ index: Int) -> Bool {
+        if isSearchActive && !searchText.isEmpty && searchFilteredIndices.contains(index) {
+            return true
         }
-        
-        return threadReplies.count
+        return hiddenFilteredReplyIndices.contains(index)
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -1693,6 +1701,18 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             let attributedText = threadReplies[actualIndex]
             let boardNumber = threadBoardReplyNumber[actualIndex]
             let isFiltered = filteredReplyIndices.contains(actualIndex)
+            let displayedText: NSAttributedString
+            if isFiltered, let reason = filteredReplyReasons[actualIndex], !reason.isEmpty {
+                displayedText = NSAttributedString(
+                    string: "Filtered: \(reason)",
+                    attributes: [
+                        .foregroundColor: ThemeManager.shared.secondaryTextColor,
+                        .font: UIFont.italicSystemFont(ofSize: 15)
+                    ]
+                )
+            } else {
+                displayedText = attributedText
+            }
 
             // Get the reply count for this post (how many posts replied to it)
             let replyCount = threadBoardReplies[boardNumber]?.count ?? 0
@@ -1705,7 +1725,7 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
 
             // Configure the cell with text and other details
             cell.configure(withImage: hasImage,
-                           text: attributedText,
+                           text: displayedText,
                            boardNumber: boardNumber,
                            isFiltered: isFiltered,
                            replyCount: replyCount,
@@ -1714,10 +1734,10 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             // Set the attributed text based on whether the cell has an image
             if hasImage {
                 //print("Debug: Cell contains an image, setting replyText")
-                cell.replyText.attributedText = attributedText
+                cell.replyText.attributedText = displayedText
             } else {
                 //print("Debug: Cell does not contain an image, setting replyTextNoImage")
-                cell.replyTextNoImage.attributedText = attributedText
+                cell.replyTextNoImage.attributedText = displayedText
             }
             
             // Set up image if present
@@ -2303,6 +2323,17 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
         let countryName = post["country_name"].stringValue  // Country name
         let timestamp = post["time"].int  // Unix timestamp
         let fileHash = post["md5"].stringValue  // File hash (if available)
+        let name = post["name"].stringValue
+        let email = post["email"].stringValue
+        let capcode = post["capcode"].stringValue
+        let passDate = post["since4pass"].stringValue
+        let dimensions: String?
+        if let width = post["w"].int, let height = post["h"].int {
+            dimensions = "\(width)x\(height)"
+        } else {
+            dimensions = nil
+        }
+        let fileSize = post["fsize"].int.map { "\($0)" }
 
         // Create PostMetadata for advanced filtering
         let metadata = PostMetadata(
@@ -2315,8 +2346,19 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             timestamp: timestamp,
             imageUrl: imageURL.isEmpty ? nil : imageURL,
             imageExtension: imageExtension.isEmpty ? nil : imageExtension,
-            imageName: imageName.isEmpty ? nil : imageName,
-            fileHash: fileHash.isEmpty ? nil : fileHash
+            imageName: imageName.isEmpty ? nil : "\(imageName)\(imageExtension)",
+            fileHash: fileHash.isEmpty ? nil : fileHash,
+            boardAbv: boardAbv,
+            threadNumber: threadNumber,
+            subject: post["sub"].stringValue.nilIfEmptyForFiltering,
+            name: name.nilIfEmptyForFiltering,
+            email: email.nilIfEmptyForFiltering,
+            capcode: capcode.nilIfEmptyForFiltering,
+            passDate: passDate.nilIfEmptyForFiltering,
+            imageDimensions: dimensions,
+            imageFileSize: fileSize,
+            isOP: postMetadataList.isEmpty,
+            isTopThread: postMetadataList.isEmpty
         )
         postMetadataList.append(metadata)
     }
@@ -3115,6 +3157,13 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             return replyContent.replyNumbers.firstIndex(of: originalNumber)
         })
         newThreadVC.filteredReplyIndices = filteredIndicesInNew
+        newThreadVC.filteredReplyReasons = filteredReplyReasons.reduce(into: [Int: String]()) { partial, item in
+            guard threadBoardReplyNumber.indices.contains(item.key) else { return }
+            let originalNumber = threadBoardReplyNumber[item.key]
+            if let newIndex = replyContent.replyNumbers.firstIndex(of: originalNumber) {
+                partial[newIndex] = item.value
+            }
+        }
 
         print("Selected post: \(postNumber)")
         print("Filtered replies: \(replyContent.replyNumbers.dropFirst())")
@@ -4333,6 +4382,8 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     private func applyContentFiltering() {
         // Clear existing filters before reapplying
         filteredReplyIndices.removeAll()
+        hiddenFilteredReplyIndices.removeAll()
+        filteredReplyReasons.removeAll()
 
         let filterManager = ContentFilterManager.shared
 
@@ -4359,7 +4410,9 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
             return
         }
 
-        // Apply filters to each reply using PostMetadata
+        var metadataForResults: [PostMetadata] = []
+        metadataForResults.reserveCapacity(threadReplies.count)
+
         for (index, _) in threadReplies.enumerated() {
             // Use PostMetadata if available, otherwise create basic metadata
             let metadata: PostMetadata
@@ -4392,13 +4445,24 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
                     imageUrl: imageUrl,
                     imageExtension: imageExt,
                     imageName: nil,
-                    fileHash: nil
+                    fileHash: nil,
+                    boardAbv: boardAbv,
+                    threadNumber: threadNumber,
+                    isOP: index == 0,
+                    isTopThread: index == 0
                 )
             }
+            metadataForResults.append(metadata)
+        }
 
-            // Check if post should be filtered using the centralized filter manager
-            if filterManager.shouldFilter(post: metadata) {
+        let resultsByPostNumber = filterManager.filterResults(for: metadataForResults)
+        for (index, metadata) in metadataForResults.enumerated() {
+            guard let result = resultsByPostNumber[metadata.postNumber], result.isFiltered else { continue }
+            if result.showStub {
                 filteredReplyIndices.insert(index)
+                filteredReplyReasons[index] = result.reasons.joined(separator: " & ")
+            } else {
+                hiddenFilteredReplyIndices.insert(index)
             }
         }
 
@@ -4410,6 +4474,8 @@ class threadRepliesTV: UIViewController, UITableViewDelegate, UITableViewDataSou
     private func clearAllFilters() {
         // Clear local view filters
         filteredReplyIndices.removeAll()
+        hiddenFilteredReplyIndices.removeAll()
+        filteredReplyReasons.removeAll()
         debugReloadData(context: "Search filter update")
     }
 

--- a/ChannerTests/Managers/AdvancedFilterTests.swift
+++ b/ChannerTests/Managers/AdvancedFilterTests.swift
@@ -141,6 +141,75 @@ class AdvancedFilterTests: XCTestCase {
         XCTAssertFalse(filter.matches(post: recentPost))
     }
 
+    func testXTGeneralFilterMatchesSubjectAndBoard() throws {
+        let filter = try AdvancedFilter.xt("/general/i;boards:v;op:only;type:subject;reason:General", type: .xtGeneral)
+        let matchingPost = createTestPost(
+            comment: "body",
+            boardAbv: "v",
+            subject: "Daily General",
+            isOP: true
+        )
+        let wrongBoard = createTestPost(
+            comment: "body",
+            boardAbv: "g",
+            subject: "Daily General",
+            isOP: true
+        )
+        let reply = createTestPost(
+            comment: "body",
+            boardAbv: "v",
+            subject: "Daily General",
+            isOP: false
+        )
+
+        XCTAssertTrue(filter.matches(post: matchingPost))
+        XCTAssertFalse(filter.matches(post: wrongBoard))
+        XCTAssertFalse(filter.matches(post: reply))
+        XCTAssertEqual(filter.matchEffect(post: matchingPost, defaultShowStub: true)?.reason, "General")
+    }
+
+    func testXTCombinedFieldsMatch() throws {
+        let filter = try AdvancedFilter.xt("/wallpaper\\n1024\\n1920x1080/;type:filename+filesize+dimensions", type: .xtGeneral)
+        let post = createTestPost(
+            imageName: "wallpaper",
+            imageDimensions: "1920x1080",
+            imageFileSize: "1024"
+        )
+
+        XCTAssertTrue(filter.matches(post: post))
+    }
+
+    func testMD5FilterUsesExactMatching() {
+        let filter = AdvancedFilter.md5("abc123")
+        let matchingPost = createTestPost(fileHash: "abc123")
+        let partialPost = createTestPost(fileHash: "abc123-extra")
+
+        XCTAssertTrue(filter.matches(post: matchingPost))
+        XCTAssertFalse(filter.matches(post: partialPost))
+    }
+
+    func testRecursiveReplyResults() throws {
+        ContentFilterManager.shared.clearAllAdvancedFilters()
+        XCTAssertTrue(ContentFilterManager.shared.addXTFilterLine("/bait/i;replies;reason:Bait"))
+
+        let op = createTestPost(postNumber: "100", comment: "bait")
+        let reply = createTestPost(postNumber: "101", comment: ">>100 reply")
+        let nestedReply = createTestPost(postNumber: "102", comment: ">>101 reply")
+        let results = ContentFilterManager.shared.filterResults(for: [op, reply, nestedReply])
+
+        XCTAssertTrue(results["100"]?.isFiltered == true)
+        XCTAssertTrue(results["101"]?.isFiltered == true)
+        XCTAssertTrue(results["102"]?.isFiltered == true)
+    }
+
+    func testQuickMD5FilterAddsExactFilter() {
+        ContentFilterManager.shared.clearAllAdvancedFilters()
+        XCTAssertTrue(ContentFilterManager.shared.quickFilterMD5("md5hash"))
+        let post = createTestPost(fileHash: "md5hash")
+
+        XCTAssertTrue(ContentFilterManager.shared.shouldFilter(post: post))
+    }
+
     func testDisabledFilterDoesNotMatch() {
         var filter = AdvancedFilter.keyword("test")
         filter.isEnabled = false
@@ -295,7 +364,13 @@ class AdvancedFilterTests: XCTestCase {
         timestamp: Int? = nil,
         imageUrl: String? = nil,
         imageExtension: String? = nil,
-        imageName: String? = nil
+        imageName: String? = nil,
+        fileHash: String? = nil,
+        boardAbv: String? = nil,
+        subject: String? = nil,
+        imageDimensions: String? = nil,
+        imageFileSize: String? = nil,
+        isOP: Bool = false
     ) -> PostMetadata {
         return PostMetadata(
             postNumber: postNumber,
@@ -307,7 +382,13 @@ class AdvancedFilterTests: XCTestCase {
             timestamp: timestamp,
             imageUrl: imageUrl ?? (imageExtension != nil ? "https://example.com/test\(imageExtension!)" : nil),
             imageExtension: imageExtension,
-            imageName: imageName
+            imageName: imageName,
+            fileHash: fileHash,
+            boardAbv: boardAbv,
+            subject: subject,
+            imageDimensions: imageDimensions,
+            imageFileSize: imageFileSize,
+            isOP: isOP
         )
     }
 }


### PR DESCRIPTION
## Summary
- Added XT-compatible advanced filter parsing for subject, email, capcode, pass date, dimensions, filesize, MD5, and general multi-field rules.
- Extended filtering results to carry XT-style behavior like stubs, reasons, recursive hiding, top pinning, filtered backlinks, and anonymize mode.
- Wired the new filter semantics into thread replies, board/catalog filtering, and the advanced filter UI.
- Added focused unit coverage for XT parsing, exact MD5 filtering, quick MD5 filters, and recursive hide behavior.

## Testing
- Built the iOS simulator target successfully.
- Ran the `AdvancedFilterTests` suite and the new XT-focused test cases passed.